### PR TITLE
chore: standardize error handling

### DIFF
--- a/.changeset/itchy-gifts-prove.md
+++ b/.changeset/itchy-gifts-prove.md
@@ -1,0 +1,9 @@
+---
+"zaku": patch
+---
+
+Standardize error handling
+
+- Use structured error types
+- Replace most `.unwrap()`/`.expect()` calls with `Result` based handling
+- Use `CmdResult` for all tauri commands

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -924,6 +924,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,7 +3964,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -6410,6 +6430,7 @@ version = "0.6.0"
 dependencies = [
  "cookie",
  "cookie_store",
+ "derive_more 2.0.1",
  "dirs",
  "indexmap 2.10.0",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2.2.0", features = [] }
 [dependencies]
 cookie = { version = "0.18.1" }
 cookie_store = { version = "0.21.1" }
+derive_more = { version = "2.0.1", features = ["from"] }
 dirs = { version = "6.0.0" }
 indexmap = { version = "2.9.0", features = ["serde"] }
 once_cell = { version = "1.21.3" }

--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -1,144 +1,111 @@
 use std::collections::HashMap;
-use std::fs::{self, File};
-use std::io::{Error, ErrorKind, Write};
+use std::fs;
 use std::path::Path;
 use toml;
 
 pub mod models;
 
-use crate::{collection::models::CreateCollectionDto, utils};
+use crate::{
+    collection::models::CreateCollectionDto,
+    error::{Error, Result},
+    utils,
+};
 
-pub fn displayname_by_relpath(space_abspath: &Path) -> Result<HashMap<String, String>, Error> {
-    let displayname_file_abspath = space_abspath.join(".zaku/collections/display_name");
+pub fn displayname_by_relpath(space_abspath: &Path) -> Result<HashMap<String, String>> {
+    let displayname_file_abspath = space_abspath.join(".zaku/collections/display_name.toml");
 
-    let content = match fs::read_to_string(&displayname_file_abspath.with_extension("toml")) {
+    let content = match fs::read_to_string(&displayname_file_abspath) {
         Ok(content) => content,
-        Err(err) if err.kind() == ErrorKind::NotFound => {
-            let initialized_hash_map: HashMap<String, String> = HashMap::new();
+        Err(_) => {
+            let empty_map: HashMap<String, String> = HashMap::new();
 
             if let Some(parent) = displayname_file_abspath.parent() {
-                fs::create_dir_all(parent)
-                    .expect("Failed to create display name's parent directories");
+                fs::create_dir_all(parent)?;
             }
 
-            let mut display_name_file =
-                File::create(&displayname_file_abspath.with_extension("toml"))
-                    .expect("Failed to create `display_name.toml`");
-            display_name_file
-                .write_all(
-                    toml::to_string_pretty(&initialized_hash_map)
-                        .expect("Failed to serialize empty TOML")
-                        .as_bytes(),
-                )
-                .expect("Failed to write to config file");
-
-            return Ok(initialized_hash_map);
-        }
-        Err(err) => {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!(
-                    "Failed to load {}: {}",
-                    displayname_file_abspath.display(),
-                    err
-                ),
-            ));
+            let serialized = toml::to_string_pretty(&empty_map)?;
+            fs::write(&displayname_file_abspath, &serialized)?;
+            serialized
         }
     };
 
-    let display_names: HashMap<String, String> = match toml::from_str(&content) {
-        Ok(display_names) => display_names,
-        Err(err) => {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Failed to parse TOML: {}", err),
-            ));
-        }
-    };
-
-    return Ok(display_names);
+    Ok(toml::from_str(&content)?)
 }
 
 pub fn save_displayname_if_missing(
     space_abspath: &Path,
     collection_relpath: &str,
     collection_display_name: &str,
-) -> Result<(), Error> {
-    let displayname_file_abspath = space_abspath.join(".zaku/collections/display_name");
+) -> Result<()> {
+    let displayname_file_abspath = space_abspath.join(".zaku/collections/display_name.toml");
 
-    let mut collection_name_by_relpath = displayname_by_relpath(&space_abspath)
-        .expect("Failed to get display names by relative path");
+    let mut collection_name_by_relpath = displayname_by_relpath(space_abspath)?;
 
     collection_name_by_relpath
         .entry(collection_relpath.to_string())
-        .or_insert(collection_display_name.to_string());
+        .or_insert_with(|| collection_display_name.to_string());
 
-    let toml_content =
-        toml::to_string_pretty(&collection_name_by_relpath).expect("Failed to serialize TOML");
+    let toml_content = toml::to_string_pretty(&collection_name_by_relpath)?;
 
-    fs::write(
-        &displayname_file_abspath.with_extension("toml"),
-        toml_content,
-    )
-    .expect("Failed to write display names to file");
+    fs::write(&displayname_file_abspath, toml_content)?;
 
-    return Ok(());
+    Ok(())
 }
 
 pub fn create_collections_all(
     space_abspath: &Path,
     create_collection_dto: &CreateCollectionDto,
-) -> Result<String, Error> {
+) -> Result<String> {
+    if create_collection_dto.relpath.trim().is_empty() {
+        return Err(Error::FileNotFound("Collection name is missing".into()));
+    }
+
     let mut dirs = Vec::new();
     for dir_display_name in create_collection_dto.relpath.split('/') {
         let dir_display_name = dir_display_name.trim();
         let dir_sanitized_name = dir_display_name
             .to_lowercase()
             .split_whitespace()
-            .collect::<Vec<&str>>()
+            .collect::<Vec<_>>()
             .join("-");
 
         if dir_display_name.is_empty() || dir_sanitized_name.is_empty() {
             continue;
         }
 
-        dirs.push((dir_sanitized_name.clone(), dir_display_name.to_string()));
+        dirs.push((dir_sanitized_name, dir_display_name.to_string()));
     }
 
-    let collection_parent_abspath =
-        space_abspath.join(create_collection_dto.parent_relpath.clone());
+    let collection_parent_abspath = space_abspath.join(&create_collection_dto.parent_relpath);
     let mut collections_relpath = String::new();
 
     for (dir_sanitized_name, dir_display_name) in &dirs {
         let mut cur_collection_relpath = collections_relpath.clone();
 
         if !cur_collection_relpath.is_empty() {
-            cur_collection_relpath.push_str("/");
+            cur_collection_relpath.push('/');
         }
         cur_collection_relpath.push_str(dir_sanitized_name);
 
-        fs::create_dir(&collection_parent_abspath.join(cur_collection_relpath.clone()))
-            .unwrap_or_else(|err| {
-                if err.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create collection directory: {:?}", err);
-                }
-            });
+        let target_dir = collection_parent_abspath.join(&cur_collection_relpath);
+        let dir_exists = fs::metadata(&target_dir).is_ok();
+        if !dir_exists {
+            fs::create_dir(&target_dir)?;
+        };
 
         let cur_collection_relpath = utils::join_str_paths(vec![
-            create_collection_dto.parent_relpath.as_str(),
-            cur_collection_relpath.as_str(),
+            &create_collection_dto.parent_relpath,
+            &cur_collection_relpath,
         ]);
 
-        save_displayname_if_missing(&space_abspath, &cur_collection_relpath, &dir_display_name)
-            .unwrap_or_else(|err| {
-                eprintln!("Failed to save display name {}", err);
-            });
+        save_displayname_if_missing(space_abspath, &cur_collection_relpath, dir_display_name)
+            .map_err(|e| Error::FileReadError(format!("{}: {}", cur_collection_relpath, e)))?;
 
         if !collections_relpath.is_empty() {
-            collections_relpath.push_str("/");
+            collections_relpath.push('/');
         }
-        collections_relpath.push_str(&dir_sanitized_name);
+        collections_relpath.push_str(dir_sanitized_name);
     }
 
-    return Ok(collections_relpath);
+    Ok(collections_relpath)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -30,7 +30,7 @@ use crate::{
             SpaceReference,
         },
     },
-    state::ZakuState,
+    state::SharedState,
     store::{
         self,
         models::{SpaceCookies, SpaceSettings},
@@ -43,7 +43,7 @@ pub mod models;
 
 pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
     tauri_specta::collect_commands![
-        get_zaku_state,
+        get_sharedstate,
         create_space,
         set_active_space,
         remove_space,
@@ -77,9 +77,9 @@ pub async fn create_collection(
         });
     };
 
-    let state = app_handle.state::<Mutex<ZakuState>>();
-    let mut zaku_state = state.lock().unwrap();
-    let active_space = zaku_state
+    let sharedstate_mtx = app_handle.state::<Mutex<SharedState>>();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
+    let active_space = sharedstate
         .active_space
         .clone()
         .expect("Active space not found");
@@ -149,7 +149,7 @@ pub async fn create_collection(
         relpath: dir_relpath,
     };
 
-    zaku_state.active_space =
+    sharedstate.active_space =
         Some(
             space::parse_space(&active_space_abspath).map_err(|err| CmdErr::Err {
                 message: format!(
@@ -193,9 +193,9 @@ pub fn move_treeitem(
     move_treeitem_dto: MoveTreeItemDto,
     app_handle: tauri::AppHandle,
 ) -> CmdResult<()> {
-    let state = app_handle.state::<Mutex<ZakuState>>();
-    let mut zaku_state = state.lock().unwrap();
-    let active_space = zaku_state
+    let sharedstate_mtx = app_handle.state::<Mutex<SharedState>>();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
+    let active_space = sharedstate
         .active_space
         .clone()
         .expect("Active space not found");
@@ -210,7 +210,7 @@ pub fn move_treeitem(
     fs::rename(src_abspath, dest_abspath).expect("Unable to move tree item");
 
     match space::parse_space(&active_space_abspath) {
-        Ok(active_space) => zaku_state.active_space = Some(active_space),
+        Ok(active_space) => sharedstate.active_space = Some(active_space),
         Err(err) => {
             return Err(CmdErr::Err {
                 message: format!("Failed to parse space after moving the tree item: {}", err),
@@ -278,9 +278,9 @@ pub async fn create_req(
         });
     }
 
-    let state = app_handle.state::<Mutex<ZakuState>>();
-    let mut zaku_state = state.lock().unwrap();
-    let active_space = zaku_state
+    let sharedstate_mtx = app_handle.state::<Mutex<SharedState>>();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
+    let active_space = sharedstate
         .active_space
         .clone()
         .expect("Active space not found");
@@ -346,7 +346,7 @@ pub async fn create_req(
     };
 
     match space::parse_space(&active_space_abspath) {
-        Ok(active_space) => zaku_state.active_space = Some(active_space),
+        Ok(active_space) => sharedstate.active_space = Some(active_space),
         Err(err) => {
             return Err(CmdErr::Err {
                 message: format!("Failed to parse space after creating the request: {}", err),
@@ -484,7 +484,7 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
 #[tauri::command]
 pub async fn create_space(
     create_space_dto: CreateSpaceDto,
-    state: tauri::State<'_, Mutex<ZakuState>>,
+    sharedstate_mtx: tauri::State<'_, Mutex<SharedState>>,
 ) -> CmdResult<SpaceReference> {
     let location = PathBuf::from(create_space_dto.location.as_str());
     if !location.exists() {
@@ -495,7 +495,7 @@ pub async fn create_space(
 
     let space_abspath = location.join(create_space_dto.name.clone());
     let mut spacerefs = store::get_spacerefs();
-    let mut zaku_state = state.lock().unwrap();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
 
     if spacerefs
         .iter()
@@ -555,8 +555,8 @@ pub async fn create_space(
 
     match space::parse_space(&PathBuf::from(spaceref.clone().path)) {
         Ok(active_space) => {
-            zaku_state.active_space = Some(active_space);
-            zaku_state.spacerefs = spacerefs;
+            sharedstate.active_space = Some(active_space);
+            sharedstate.spacerefs = spacerefs;
         }
         Err(_) => {
             // TODO - handle
@@ -570,9 +570,9 @@ pub async fn create_space(
 #[tauri::command]
 pub fn set_active_space(
     space_reference: SpaceReference,
-    state: tauri::State<Mutex<ZakuState>>,
+    sharedstate_mtx: tauri::State<Mutex<SharedState>>,
 ) -> CmdResult<()> {
-    let mut zaku_state = state.lock().unwrap();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
     let space_abspath = PathBuf::from(space_reference.path.as_str());
 
     if !space_abspath.exists() {
@@ -595,8 +595,8 @@ pub fn set_active_space(
                 }
             })?;
 
-            zaku_state.active_space = Some(space);
-            zaku_state.spacerefs = store::get_spacerefs();
+            sharedstate.active_space = Some(space);
+            sharedstate.spacerefs = store::get_spacerefs();
 
             Ok(())
         }
@@ -610,9 +610,9 @@ pub fn set_active_space(
 #[tauri::command]
 pub fn remove_space(
     space_reference: SpaceReference,
-    state: tauri::State<Mutex<ZakuState>>,
+    sharedstate_mtx: tauri::State<Mutex<SharedState>>,
 ) -> CmdResult<()> {
-    let mut zaku_state = state.lock().unwrap();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
     store::remove_spaceref(space_reference).map_err(|e| CmdErr::Err {
         message: e.to_string(),
     })?;
@@ -620,7 +620,7 @@ pub fn remove_space(
     let active_space = store::get_active_spaceref();
 
     if active_space.is_none() {
-        zaku_state.active_space = None;
+        sharedstate.active_space = None;
 
         if let Some(valid_space_reference) = space::first_valid_spaceref() {
             store::set_active_spaceref(valid_space_reference.clone()).map_err(|e| CmdErr::Err {
@@ -630,12 +630,12 @@ pub fn remove_space(
             if let Ok(active_space) =
                 space::parse_space(&PathBuf::from(&valid_space_reference.path))
             {
-                zaku_state.active_space = Some(active_space);
+                sharedstate.active_space = Some(active_space);
             }
         }
     }
 
-    zaku_state.spacerefs = store::get_spacerefs();
+    sharedstate.spacerefs = store::get_spacerefs();
 
     Ok(())
 }
@@ -710,9 +710,11 @@ pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> CmdResult<ZakuState> {
-    match state.lock() {
-        Ok(zaku_state) => Ok(zaku_state.clone()),
+pub fn get_sharedstate(
+    sharedstate_mtx: tauri::State<Mutex<SharedState>>,
+) -> CmdResult<SharedState> {
+    match sharedstate_mtx.lock() {
+        Ok(sharedstate) => Ok(sharedstate.clone()),
         Err(e) => Err(CmdErr::Err {
             message: format!("State lock error: {}", e),
         }),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,23 +12,29 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_notification::{NotificationExt, PermissionState};
 
 use crate::{
-    collection,
-    collection::models::CreateCollectionDto,
+    collection::{self, models::CreateCollectionDto},
     commands::models::{
-        CreateNewCollection, CreateNewRequest, DispatchNotificationOptions, MoveTreeItemDto,
-        OpenDirDialogOpt,
+        CmdErr, CmdHttpErr, CmdResult, CreateNewCollection, CreateNewRequest,
+        DispatchNotificationOptions, MoveTreeItemDto, OpenDirDialogOpt,
     },
-    error::ZakuError,
-    notifications, request,
-    request::models::{CreateRequestDto, HttpErr, HttpReq, HttpRes},
-    space,
-    space::models::{
-        CreateSpaceDto, RemoveCookieDto, SpaceConfigFile, SpaceCookie, SpaceMeta, SpaceReference,
+    notifications,
+    request::{
+        self,
+        models::{CreateRequestDto, HttpReq, HttpRes},
+    },
+    space::{
+        self,
+        models::{
+            CreateSpaceDto, RemoveCookieDto, SpaceConfigFile, SpaceCookie, SpaceMeta,
+            SpaceReference,
+        },
     },
     state::ZakuState,
-    store,
-    store::models::{SpaceCookies, SpaceSettings},
-    store::spaces::buffer,
+    store::{
+        self,
+        models::{SpaceCookies, SpaceSettings},
+        spaces::buffer,
+    },
     utils,
 };
 
@@ -39,7 +45,7 @@ pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
         get_zaku_state,
         create_space,
         set_active_space,
-        delete_space,
+        remove_space,
         get_spaceref,
         remove_cookie,
         get_space_cookies,
@@ -60,15 +66,14 @@ pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
 
 #[specta::specta]
 #[tauri::command]
-pub fn create_collection(
+pub async fn create_collection(
     create_collection_dto: CreateCollectionDto,
     app_handle: tauri::AppHandle,
-) -> Result<CreateNewCollection, ZakuError> {
+) -> CmdResult<CreateNewCollection> {
     if create_collection_dto.relpath.is_empty() {
-        return Err(ZakuError {
-            error: "Cannot create a collection without name".to_string(),
-            message: "Cannot create a collection without name".to_string(),
-        });
+        return Err(CmdErr(
+            "Cannot create a collection without name".to_string(),
+        ));
     };
 
     let state = app_handle.state::<Mutex<ZakuState>>();
@@ -107,10 +112,7 @@ pub fn create_collection(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| ZakuError {
-                    error: err.to_string(),
-                    message: "Failed to create collection's parent directories".to_string(),
-                })?;
+                    .map_err(|err| CmdErr(format!("Failed to create collection: {}", err)))?;
 
             let dir_parent_relpath = utils::join_str_paths(vec![
                 create_collection_dto.parent_relpath.as_str(),
@@ -130,10 +132,8 @@ pub fn create_collection(
         dir_sanitized_name.as_str(),
     ]);
 
-    fs::create_dir(&dir_abspath).map_err(|err| ZakuError {
-        error: err.to_string(),
-        message: "Failed to create collection".to_string(),
-    })?;
+    fs::create_dir(&dir_abspath)
+        .map_err(|err| CmdErr(format!("Failed to create collection: {}", err)))?;
 
     collection::save_displayname_if_missing(&active_space_abspath, &dir_relpath, &dir_display_name)
         .unwrap_or_else(|err| {
@@ -148,10 +148,10 @@ pub fn create_collection(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(ZakuError {
-                error: err.to_string(),
-                message: "Failed to parse space after creating the collection".to_string(),
-            })
+            return Err(CmdErr(format!(
+                "Failed to parse space after creating the collection: {}",
+                err
+            )))
         }
     }
 
@@ -163,7 +163,7 @@ pub fn create_collection(
 pub async fn open_dir_dialog(
     options: Option<OpenDirDialogOpt>,
     app_handle: tauri::AppHandle,
-) -> Result<Option<String>, String> {
+) -> CmdResult<Option<String>> {
     let mut dialog_builder = app_handle.dialog().file();
 
     if let Some(OpenDirDialogOpt {
@@ -188,7 +188,7 @@ pub async fn open_dir_dialog(
 pub fn move_treeitem(
     move_treeitem_dto: MoveTreeItemDto,
     app_handle: tauri::AppHandle,
-) -> Result<(), ZakuError> {
+) -> CmdResult<()> {
     let state = app_handle.state::<Mutex<ZakuState>>();
     let mut zaku_state = state.lock().unwrap();
     let active_space = zaku_state
@@ -208,10 +208,10 @@ pub fn move_treeitem(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(ZakuError {
-                error: err.to_string(),
-                message: "Failed to parse space after moving the tree item".to_string(),
-            })
+            return Err(CmdErr(format!(
+                "Failed to parse space after moving the tree item: {}",
+                err
+            )));
         }
     }
 
@@ -220,28 +220,22 @@ pub fn move_treeitem(
 
 #[specta::specta]
 #[tauri::command]
-pub fn is_notif_enabled(app_handle: tauri::AppHandle) -> Result<bool, ZakuError> {
+pub fn is_notif_enabled(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .permission_state()
-        .map_err(|err| ZakuError {
-            error: err.to_string(),
-            message: "Failed to get current permissions state.".to_string(),
-        })?;
+        .map_err(|err| CmdErr(format!("Failed to get current permissions state: {}", err)))?;
 
     return Ok(permission_state == PermissionState::Granted);
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn request_notif_access(app_handle: tauri::AppHandle) -> Result<bool, ZakuError> {
+pub fn request_notif_access(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .request_permission()
-        .map_err(|err| ZakuError {
-            error: err.to_string(),
-            message: "Failed to request for permissions.".to_string(),
-        })?;
+        .map_err(|err| CmdErr(format!("Failed to request for permissions: {}", err)))?;
 
     return Ok(permission_state == PermissionState::Granted);
 }
@@ -251,33 +245,27 @@ pub fn request_notif_access(app_handle: tauri::AppHandle) -> Result<bool, ZakuEr
 pub fn dispatch_notif(
     options: DispatchNotificationOptions,
     app_handle: tauri::AppHandle,
-) -> Result<(), ZakuError> {
+) -> CmdResult<()> {
     app_handle
         .notification()
         .builder()
         .title(&options.title)
         .body(&options.body)
         .show()
-        .map_err(|err| ZakuError {
-            error: err.to_string(),
-            message: "Failed to dispatch notification.".to_string(),
-        })?;
+        .map_err(|err| CmdErr(format!("Failed to dispatch notification: {}", err)))?;
 
     return Ok(());
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn create_req(
+pub async fn create_req(
     create_req_dto: CreateRequestDto,
     app_handle: tauri::AppHandle,
-) -> Result<CreateNewRequest, ZakuError> {
+) -> CmdResult<CreateNewRequest> {
     if create_req_dto.relpath.is_empty() {
-        return Err(ZakuError {
-            error: "Cannot create a request without name".to_string(),
-            message: "Cannot create a request without name".to_string(),
-        });
-    };
+        return Err(CmdErr("Cannot create a request without name".to_string()));
+    }
 
     let state = app_handle.state::<Mutex<ZakuState>>();
     let mut zaku_state = state.lock().unwrap();
@@ -315,9 +303,11 @@ pub fn create_req(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| ZakuError {
-                    error: err.to_string(),
-                    message: "Failed to create request's parent directories".to_string(),
+                    .map_err(|err| {
+                    CmdErr(format!(
+                        "Failed to create request's parent directories: {}",
+                        err
+                    ))
                 })?;
 
             let file_parent_relpath = utils::join_str_paths(vec![
@@ -338,10 +328,8 @@ pub fn create_req(
         format!("{}.toml", file_sanitized_name).as_str(),
     ]);
 
-    request::create_reqtoml(&file_abspath, &file_display_name).map_err(|err| ZakuError {
-        error: err.to_string(),
-        message: "Failed to create request file".to_string(),
-    })?;
+    request::create_reqtoml(&file_abspath, &file_display_name)
+        .map_err(|err| CmdErr(format!("Failed to create request file: {}", err)))?;
 
     let create_new_result = CreateNewRequest {
         parent_relpath: file_parent_relpath,
@@ -351,10 +339,10 @@ pub fn create_req(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(ZakuError {
-                error: err.to_string(),
-                message: "Failed to parse space after creating the request".to_string(),
-            })
+            return Err(CmdErr(format!(
+                "Failed to parse space after creating the request: {}",
+                err
+            )));
         }
     }
 
@@ -363,24 +351,35 @@ pub fn create_req(
 
 #[specta::specta]
 #[tauri::command]
-pub fn persist_to_reqbuf(space_abspath: &str, relpath: &str, request: HttpReq) {
+pub async fn persist_to_reqbuf(
+    space_abspath: &str,
+    relpath: &str,
+    request: HttpReq,
+) -> CmdResult<()> {
     let abs = Path::new(space_abspath);
     let rel = Path::new(relpath);
     buffer::persist_req_to_spacebuf(abs, rel, request);
+
+    Ok(())
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) {
+pub async fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) -> CmdResult<()> {
     let abs = Path::new(space_abspath);
     let rel = Path::new(req_relpath);
     buffer::write_reqbuf_to_reqtoml(abs, rel).unwrap();
+
+    Ok(())
 }
 
 #[specta::specta]
 #[tauri::command]
-pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> Result<HttpRes, HttpErr> {
-    let active_space = store::get_active_spaceref().ok_or(HttpErr {
+pub async fn http_req(
+    req: HttpReq,
+    app_handle: tauri::AppHandle,
+) -> CmdResult<HttpRes, CmdHttpErr> {
+    let active_space = store::get_active_spaceref().ok_or(CmdHttpErr {
         message: "no active space".into(),
         code: None,
     })?;
@@ -390,16 +389,16 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> Result<Http
     let client = reqwest::Client::builder()
         .cookie_provider(Arc::clone(&cookie_store))
         .build()
-        .map_err(|e| HttpErr {
+        .map_err(|e| CmdHttpErr {
             message: e.to_string(),
             code: None,
         })?;
     let cfg = &req.config;
-    let url = cfg.url.raw.clone().ok_or(HttpErr {
+    let url = cfg.url.raw.clone().ok_or(CmdHttpErr {
         message: "missing URL".into(),
         code: None,
     })?;
-    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| HttpErr {
+    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| CmdHttpErr {
         message: e.to_string(),
         code: None,
     })?;
@@ -429,7 +428,7 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> Result<Http
     }
 
     let start = Instant::now();
-    let resp = builder.send().await.map_err(|e| HttpErr {
+    let resp = builder.send().await.map_err(|e| CmdHttpErr {
         message: e.to_string(),
         code: None,
     })?;
@@ -455,7 +454,7 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> Result<Http
         .filter_map(|v| RawCookie::parse(v).ok())
         .map(|ck| SpaceCookie::from_raw_cookie(&ck))
         .collect::<Vec<SpaceCookie>>();
-    let data = resp.text().await.map_err(|e| HttpErr {
+    let data = resp.text().await.map_err(|e| CmdHttpErr {
         message: e.to_string(),
         code: Some(status),
     })?;
@@ -474,16 +473,16 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> Result<Http
 
 #[specta::specta]
 #[tauri::command]
-pub fn create_space(
+pub async fn create_space(
     create_space_dto: CreateSpaceDto,
-    state: tauri::State<Mutex<ZakuState>>,
-) -> Result<SpaceReference, ZakuError> {
+    state: tauri::State<'_, Mutex<ZakuState>>,
+) -> CmdResult<SpaceReference> {
     let location = PathBuf::from(create_space_dto.location.as_str());
     if !location.exists() {
-        return Err(ZakuError {
-            error: create_space_dto.location,
-            message: "Location does not exist.".to_string(),
-        });
+        return Err(CmdErr(format!(
+            "Location does not exist: {}",
+            create_space_dto.location
+        )));
     }
 
     let space_abspath = location.join(create_space_dto.name.clone());
@@ -494,16 +493,16 @@ pub fn create_space(
         .iter()
         .any(|sr| sr.path == space_abspath.to_string_lossy())
     {
-        return Err(ZakuError {
-            error: space_abspath.to_string_lossy().to_string(),
-            message: "Space already exists in saved spaces.".to_string(),
-        });
+        return Err(CmdErr(format!(
+            "Space already exists in saved spaces: {}",
+            space_abspath.to_string_lossy()
+        )));
     }
     if space_abspath.exists() {
-        return Err(ZakuError {
-            error: space_abspath.to_string_lossy().to_string(),
-            message: "Directory with this name already exists.".to_string(),
-        });
+        return Err(CmdErr(format!(
+            "Directory with this name already exists: {}",
+            space_abspath.to_string_lossy()
+        )));
     }
 
     fs::create_dir(&space_abspath).expect("Failed to create space directory");
@@ -556,15 +555,15 @@ pub fn create_space(
 pub fn set_active_space(
     space_reference: SpaceReference,
     state: tauri::State<Mutex<ZakuState>>,
-) -> Result<(), ZakuError> {
+) -> CmdResult<()> {
     let mut zaku_state = state.lock().unwrap();
     let space_abspath = PathBuf::from(space_reference.path.as_str());
 
     if !space_abspath.exists() {
-        return Err(ZakuError {
-            error: space_abspath.to_string_lossy().to_string(),
-            message: "Directory does not exist.".to_string(),
-        });
+        return Err(CmdErr(format!(
+            "Directory does not exist: {}",
+            space_abspath.to_string_lossy()
+        )));
     }
 
     match space::parse_space(&space_abspath) {
@@ -577,18 +576,15 @@ pub fn set_active_space(
 
             return Ok(());
         }
-        Err(err) => Err(ZakuError {
-            error: err.to_string(),
-            message: "Unable to parse space.".to_string(),
-        }),
+        Err(err) => Err(CmdErr(format!("Unable to parse space: {}", err))),
     }
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn delete_space(space_reference: SpaceReference, state: tauri::State<Mutex<ZakuState>>) -> () {
+pub fn remove_space(space_reference: SpaceReference, state: tauri::State<Mutex<ZakuState>>) -> () {
     let mut zaku_state = state.lock().unwrap();
-    store::delete_spaceref(space_reference);
+    store::remove_spaceref(space_reference);
 
     let active_space = store::get_active_spaceref();
 
@@ -617,7 +613,7 @@ pub fn delete_space(space_reference: SpaceReference, state: tauri::State<Mutex<Z
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_spaceref(path: String) -> Result<SpaceReference, ZakuError> {
+pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
     let space_abspath = PathBuf::from(path.as_str());
 
     match space::parse_spacecfg(&space_abspath) {
@@ -630,24 +626,20 @@ pub fn get_spaceref(path: String) -> Result<SpaceReference, ZakuError> {
             return Ok(space_reference);
         }
         Err(err) => {
-            return Err(ZakuError {
-                error: err.to_string(),
-                message: "Unable to parse space.".to_string(),
-            });
+            return Err(CmdErr(format!("Unable to parse space: {}", err)));
         }
     }
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_space_cookies(
+pub async fn get_space_cookies(
     space_abspath: &str,
-) -> Result<HashMap<String, Vec<SpaceCookie>>, ZakuError> {
+) -> CmdResult<HashMap<String, Vec<SpaceCookie>>> {
     let cookie_store = SpaceCookies::load(space_abspath);
-    let store = cookie_store.lock().map_err(|_| ZakuError {
-        error: "CookieStoreLockFailed".into(),
-        message: "Failed to lock the cookie store".into(),
-    })?;
+    let store = cookie_store
+        .lock()
+        .map_err(|_| CmdErr("Failed to lock the cookie store (CookieStoreLockFailed)".into()))?;
 
     let cookies: Vec<SpaceCookie> = store
         .iter_any()
@@ -672,22 +664,20 @@ pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> boo
 }
 
 #[specta::specta]
-#[tauri::command(async)]
-pub fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -> Result<(), ZakuError> {
-    SpaceSettings::persist(space_abspath, &settings).map_err(|err| ZakuError {
-        error: err.to_string(),
-        message: "Failed to persist space settings.".into(),
-    })?;
+#[tauri::command]
+pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -> CmdResult<()> {
+    SpaceSettings::persist(space_abspath, &settings)
+        .map_err(|err| CmdErr(format!("Failed to persist space settings: {}", err)))?;
 
     return Ok(());
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> Result<ZakuState, String> {
+pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> CmdResult<ZakuState> {
     match state.lock() {
         Ok(zaku_state) => Ok(zaku_state.clone()),
-        Err(e) => Err(format!("State lock error: {}", e)),
+        Err(e) => Err(CmdErr(format!("State lock error: {}", e))),
     }
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,9 +14,10 @@ use tauri_plugin_notification::{NotificationExt, PermissionState};
 use crate::{
     collection::{self, models::CreateCollectionDto},
     commands::models::{
-        CmdErr, CmdHttpErr, CmdResult, CreateNewCollection, CreateNewRequest,
-        DispatchNotificationOptions, MoveTreeItemDto, OpenDirDialogOpt,
+        CreateNewCollection, CreateNewRequest, DispatchNotificationOptions, MoveTreeItemDto,
+        OpenDirDialogOpt,
     },
+    error::{CmdErr, CmdResult},
     notifications,
     request::{
         self,
@@ -71,9 +72,9 @@ pub async fn create_collection(
     app_handle: tauri::AppHandle,
 ) -> CmdResult<CreateNewCollection> {
     if create_collection_dto.relpath.is_empty() {
-        return Err(CmdErr(
-            "Cannot create a collection without name".to_string(),
-        ));
+        return Err(CmdErr::Msg {
+            message: "Cannot create a collection without name".to_string(),
+        });
     };
 
     let state = app_handle.state::<Mutex<ZakuState>>();
@@ -112,7 +113,9 @@ pub async fn create_collection(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| CmdErr(format!("Failed to create collection: {}", err)))?;
+                    .map_err(|err| CmdErr::Msg {
+                    message: format!("Failed to create collection: {}", err),
+                })?;
 
             let dir_parent_relpath = utils::join_str_paths(vec![
                 create_collection_dto.parent_relpath.as_str(),
@@ -132,8 +135,9 @@ pub async fn create_collection(
         dir_sanitized_name.as_str(),
     ]);
 
-    fs::create_dir(&dir_abspath)
-        .map_err(|err| CmdErr(format!("Failed to create collection: {}", err)))?;
+    fs::create_dir(&dir_abspath).map_err(|err| CmdErr::Msg {
+        message: format!("Failed to create collection: {}", err),
+    })?;
 
     collection::save_displayname_if_missing(&active_space_abspath, &dir_relpath, dir_display_name)
         .unwrap_or_else(|err| {
@@ -145,12 +149,15 @@ pub async fn create_collection(
         relpath: dir_relpath,
     };
 
-    zaku_state.active_space = Some(space::parse_space(&active_space_abspath).map_err(|err| {
-        CmdErr(format!(
-            "Failed to parse space after creating the collection: {}",
-            err
-        ))
-    })?);
+    zaku_state.active_space =
+        Some(
+            space::parse_space(&active_space_abspath).map_err(|err| CmdErr::Msg {
+                message: format!(
+                    "Failed to parse space after creating the collection: {}",
+                    err
+                ),
+            })?,
+        );
 
     Ok(create_new_collection)
 }
@@ -205,10 +212,9 @@ pub fn move_treeitem(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(CmdErr(format!(
-                "Failed to parse space after moving the tree item: {}",
-                err
-            )));
+            return Err(CmdErr::Msg {
+                message: format!("Failed to parse space after moving the tree item: {}", err),
+            });
         }
     }
 
@@ -221,7 +227,9 @@ pub fn is_notif_enabled(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .permission_state()
-        .map_err(|err| CmdErr(format!("Failed to get current permissions state: {}", err)))?;
+        .map_err(|err| CmdErr::Msg {
+            message: format!("Failed to get current permissions state: {}", err),
+        })?;
 
     Ok(permission_state == PermissionState::Granted)
 }
@@ -232,7 +240,9 @@ pub fn request_notif_access(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .request_permission()
-        .map_err(|err| CmdErr(format!("Failed to request for permissions: {}", err)))?;
+        .map_err(|err| CmdErr::Msg {
+            message: format!("Failed to request for permissions: {}", err),
+        })?;
 
     Ok(permission_state == PermissionState::Granted)
 }
@@ -249,7 +259,9 @@ pub fn dispatch_notif(
         .title(&options.title)
         .body(&options.body)
         .show()
-        .map_err(|err| CmdErr(format!("Failed to dispatch notification: {}", err)))?;
+        .map_err(|err| CmdErr::Msg {
+            message: format!("Failed to dispatch notification: {}", err),
+        })?;
 
     Ok(())
 }
@@ -261,7 +273,9 @@ pub async fn create_req(
     app_handle: tauri::AppHandle,
 ) -> CmdResult<CreateNewRequest> {
     if create_req_dto.relpath.is_empty() {
-        return Err(CmdErr("Cannot create a request without name".to_string()));
+        return Err(CmdErr::Msg {
+            message: "Cannot create a request without name".to_string(),
+        });
     }
 
     let state = app_handle.state::<Mutex<ZakuState>>();
@@ -300,11 +314,8 @@ pub async fn create_req(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| {
-                    CmdErr(format!(
-                        "Failed to create request's parent directories: {}",
-                        err
-                    ))
+                    .map_err(|err| CmdErr::Msg {
+                    message: format!("Failed to create request's parent directories: {}", err),
                 })?;
 
             let file_parent_relpath = utils::join_str_paths(vec![
@@ -325,8 +336,9 @@ pub async fn create_req(
         format!("{}.toml", file_sanitized_name).as_str(),
     ]);
 
-    request::create_reqtoml(&file_abspath, file_display_name)
-        .map_err(|err| CmdErr(format!("Failed to create request file: {}", err)))?;
+    request::create_reqtoml(&file_abspath, file_display_name).map_err(|err| CmdErr::Msg {
+        message: format!("Failed to create request file: {}", err),
+    })?;
 
     let create_new_result = CreateNewRequest {
         parent_relpath: file_parent_relpath,
@@ -336,10 +348,9 @@ pub async fn create_req(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(CmdErr(format!(
-                "Failed to parse space after creating the request: {}",
-                err
-            )));
+            return Err(CmdErr::Msg {
+                message: format!("Failed to parse space after creating the request: {}", err),
+            });
         }
     }
 
@@ -372,13 +383,9 @@ pub async fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) -> 
 
 #[specta::specta]
 #[tauri::command]
-pub async fn http_req(
-    req: HttpReq,
-    app_handle: tauri::AppHandle,
-) -> CmdResult<HttpRes, CmdHttpErr> {
-    let active_space = store::get_active_spaceref().ok_or(CmdHttpErr {
-        message: "no active space".into(),
-        code: None,
+pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<HttpRes> {
+    let active_space = store::get_active_spaceref().ok_or(CmdErr::Msg {
+        message: "No active space".into(),
     })?;
     let space_abspath = active_space.path.as_str();
     let cookie_store = SpaceCookies::load(space_abspath);
@@ -386,18 +393,15 @@ pub async fn http_req(
     let client = reqwest::Client::builder()
         .cookie_provider(Arc::clone(&cookie_store))
         .build()
-        .map_err(|e| CmdHttpErr {
+        .map_err(|e| CmdErr::Msg {
             message: e.to_string(),
-            code: None,
         })?;
     let cfg = &req.config;
-    let url = cfg.url.raw.clone().ok_or(CmdHttpErr {
-        message: "missing URL".into(),
-        code: None,
+    let url = cfg.url.raw.clone().ok_or(CmdErr::Msg {
+        message: "Missing URL".into(),
     })?;
-    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| CmdHttpErr {
+    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| CmdErr::Msg {
         message: e.to_string(),
-        code: None,
     })?;
     let mut builder = client.request(method, &url);
     for (enabled, key, value) in &cfg.headers {
@@ -425,9 +429,8 @@ pub async fn http_req(
     }
 
     let start = Instant::now();
-    let resp = builder.send().await.map_err(|e| CmdHttpErr {
+    let resp = builder.send().await.map_err(|e| CmdErr::Msg {
         message: e.to_string(),
-        code: None,
     })?;
     if space_settings.notifications.audio.on_req_finish {
         let app_handle = app_handle.clone();
@@ -451,7 +454,7 @@ pub async fn http_req(
         .filter_map(|v| RawCookie::parse(v).ok())
         .map(|ck| SpaceCookie::from_raw_cookie(&ck))
         .collect::<Vec<SpaceCookie>>();
-    let data = resp.text().await.map_err(|e| CmdHttpErr {
+    let data = resp.text().await.map_err(|e| CmdErr::Http {
         message: e.to_string(),
         code: Some(status),
     })?;
@@ -476,10 +479,9 @@ pub async fn create_space(
 ) -> CmdResult<SpaceReference> {
     let location = PathBuf::from(create_space_dto.location.as_str());
     if !location.exists() {
-        return Err(CmdErr(format!(
-            "Location does not exist: {}",
-            create_space_dto.location
-        )));
+        return Err(CmdErr::Msg {
+            message: format!("Location does not exist: {}", create_space_dto.location),
+        });
     }
 
     let space_abspath = location.join(create_space_dto.name.clone());
@@ -490,16 +492,20 @@ pub async fn create_space(
         .iter()
         .any(|sr| sr.path == space_abspath.to_string_lossy())
     {
-        return Err(CmdErr(format!(
-            "Space already exists in saved spaces: {}",
-            space_abspath.to_string_lossy()
-        )));
+        return Err(CmdErr::Msg {
+            message: format!(
+                "Space already exists in saved spaces: {}",
+                space_abspath.to_string_lossy()
+            ),
+        });
     }
     if space_abspath.exists() {
-        return Err(CmdErr(format!(
-            "Directory with this name already exists: {}",
-            space_abspath.to_string_lossy()
-        )));
+        return Err(CmdErr::Msg {
+            message: format!(
+                "Directory with this name already exists: {}",
+                space_abspath.to_string_lossy()
+            ),
+        });
     }
 
     fs::create_dir(&space_abspath).expect("Failed to create space directory");
@@ -557,10 +563,12 @@ pub fn set_active_space(
     let space_abspath = PathBuf::from(space_reference.path.as_str());
 
     if !space_abspath.exists() {
-        return Err(CmdErr(format!(
-            "Directory does not exist: {}",
-            space_abspath.to_string_lossy()
-        )));
+        return Err(CmdErr::Msg {
+            message: format!(
+                "Directory does not exist: {}",
+                space_abspath.to_string_lossy()
+            ),
+        });
     }
 
     match space::parse_space(&space_abspath) {
@@ -573,7 +581,9 @@ pub fn set_active_space(
 
             Ok(())
         }
-        Err(err) => Err(CmdErr(format!("Unable to parse space: {}", err))),
+        Err(err) => Err(CmdErr::Msg {
+            message: format!("Unable to parse space: {}", err),
+        }),
     }
 }
 
@@ -621,7 +631,9 @@ pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
 
             Ok(space_reference)
         }
-        Err(err) => Err(CmdErr(format!("Unable to parse space: {}", err))),
+        Err(err) => Err(CmdErr::Msg {
+            message: format!("Unable to parse space: {}", err),
+        }),
     }
 }
 
@@ -631,9 +643,9 @@ pub async fn get_space_cookies(
     space_abspath: &str,
 ) -> CmdResult<HashMap<String, Vec<SpaceCookie>>> {
     let cookie_store = SpaceCookies::load(space_abspath);
-    let store = cookie_store
-        .lock()
-        .map_err(|_| CmdErr("Failed to lock the cookie store (CookieStoreLockFailed)".into()))?;
+    let store = cookie_store.lock().map_err(|_| CmdErr::Msg {
+        message: "Failed to lock the cookie store (CookieStoreLockFailed)".into(),
+    })?;
 
     let cookies: Vec<SpaceCookie> = store
         .iter_any()
@@ -660,8 +672,9 @@ pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> Cmd
 #[specta::specta]
 #[tauri::command]
 pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -> CmdResult<()> {
-    SpaceSettings::persist(space_abspath, &settings)
-        .map_err(|err| CmdErr(format!("Failed to persist space settings: {}", err)))?;
+    SpaceSettings::persist(space_abspath, &settings).map_err(|err| CmdErr::Msg {
+        message: format!("Failed to persist space settings: {}", err),
+    })?;
 
     Ok(())
 }
@@ -671,7 +684,9 @@ pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -
 pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> CmdResult<ZakuState> {
     match state.lock() {
         Ok(zaku_state) => Ok(zaku_state.clone()),
-        Err(e) => Err(CmdErr(format!("State lock error: {}", e))),
+        Err(e) => Err(CmdErr::Msg {
+            message: format!("State lock error: {}", e),
+        }),
     }
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -135,7 +135,7 @@ pub async fn create_collection(
     fs::create_dir(&dir_abspath)
         .map_err(|err| CmdErr(format!("Failed to create collection: {}", err)))?;
 
-    collection::save_displayname_if_missing(&active_space_abspath, &dir_relpath, &dir_display_name)
+    collection::save_displayname_if_missing(&active_space_abspath, &dir_relpath, dir_display_name)
         .unwrap_or_else(|err| {
             eprintln!("Failed to save display name {}", err);
         });
@@ -145,17 +145,14 @@ pub async fn create_collection(
         relpath: dir_relpath,
     };
 
-    match space::parse_space(&active_space_abspath) {
-        Ok(active_space) => zaku_state.active_space = Some(active_space),
-        Err(err) => {
-            return Err(CmdErr(format!(
-                "Failed to parse space after creating the collection: {}",
-                err
-            )))
-        }
-    }
+    zaku_state.active_space = Some(space::parse_space(&active_space_abspath).map_err(|err| {
+        CmdErr(format!(
+            "Failed to parse space after creating the collection: {}",
+            err
+        ))
+    })?);
 
-    return Ok(create_new_collection);
+    Ok(create_new_collection)
 }
 
 #[specta::specta]
@@ -215,7 +212,7 @@ pub fn move_treeitem(
         }
     }
 
-    return Ok(());
+    Ok(())
 }
 
 #[specta::specta]
@@ -226,7 +223,7 @@ pub fn is_notif_enabled(app_handle: tauri::AppHandle) -> CmdResult<bool> {
         .permission_state()
         .map_err(|err| CmdErr(format!("Failed to get current permissions state: {}", err)))?;
 
-    return Ok(permission_state == PermissionState::Granted);
+    Ok(permission_state == PermissionState::Granted)
 }
 
 #[specta::specta]
@@ -237,7 +234,7 @@ pub fn request_notif_access(app_handle: tauri::AppHandle) -> CmdResult<bool> {
         .request_permission()
         .map_err(|err| CmdErr(format!("Failed to request for permissions: {}", err)))?;
 
-    return Ok(permission_state == PermissionState::Granted);
+    Ok(permission_state == PermissionState::Granted)
 }
 
 #[specta::specta]
@@ -254,7 +251,7 @@ pub fn dispatch_notif(
         .show()
         .map_err(|err| CmdErr(format!("Failed to dispatch notification: {}", err)))?;
 
-    return Ok(());
+    Ok(())
 }
 
 #[specta::specta]
@@ -328,7 +325,7 @@ pub async fn create_req(
         format!("{}.toml", file_sanitized_name).as_str(),
     ]);
 
-    request::create_reqtoml(&file_abspath, &file_display_name)
+    request::create_reqtoml(&file_abspath, file_display_name)
         .map_err(|err| CmdErr(format!("Failed to create request file: {}", err)))?;
 
     let create_new_result = CreateNewRequest {
@@ -346,7 +343,7 @@ pub async fn create_req(
         }
     }
 
-    return Ok(create_new_result);
+    Ok(create_new_result)
 }
 
 #[specta::specta]
@@ -461,14 +458,14 @@ pub async fn http_req(
     let size_bytes = Some(data.len() as u32);
     SpaceCookies::persist(space_abspath);
 
-    return Ok(HttpRes {
+    Ok(HttpRes {
         status: Some(status),
         data,
         headers,
         cookies,
         size_bytes,
         elapsed_ms: Some(elapsed_ms),
-    });
+    })
 }
 
 #[specta::specta]
@@ -511,7 +508,7 @@ pub async fn create_space(
     fs::create_dir(&space_config_dir).expect("Failed to create `.zaku` directory");
 
     let mut space_config_file =
-        File::create(&space_config_dir.join("config").with_extension("toml"))
+        File::create(space_config_dir.join("config").with_extension("toml"))
             .expect("Failed to create `config.toml`");
 
     let space_config = SpaceConfigFile {
@@ -547,7 +544,7 @@ pub async fn create_space(
         }
     }
 
-    return Ok(spaceref);
+    Ok(spaceref)
 }
 
 #[specta::specta]
@@ -574,7 +571,7 @@ pub fn set_active_space(
             zaku_state.active_space = Some(space);
             zaku_state.spacerefs = store::get_spacerefs();
 
-            return Ok(());
+            Ok(())
         }
         Err(err) => Err(CmdErr(format!("Unable to parse space: {}", err))),
     }
@@ -582,33 +579,32 @@ pub fn set_active_space(
 
 #[specta::specta]
 #[tauri::command]
-pub fn remove_space(space_reference: SpaceReference, state: tauri::State<Mutex<ZakuState>>) -> () {
+pub fn remove_space(
+    space_reference: SpaceReference,
+    state: tauri::State<Mutex<ZakuState>>,
+) -> CmdResult<()> {
     let mut zaku_state = state.lock().unwrap();
     store::remove_spaceref(space_reference);
 
     let active_space = store::get_active_spaceref();
 
-    if let None = active_space {
+    if active_space.is_none() {
         zaku_state.active_space = None;
 
-        match space::first_valid_spaceref() {
-            Some(valid_space_reference) => {
-                store::set_active_spaceref(valid_space_reference.clone());
+        if let Some(valid_space_reference) = space::first_valid_spaceref() {
+            store::set_active_spaceref(valid_space_reference.clone());
 
-                match space::parse_space(&PathBuf::from(valid_space_reference.clone().path)) {
-                    Ok(active_space) => {
-                        zaku_state.active_space = Some(active_space);
-                    }
-                    Err(_) => {}
-                }
+            if let Ok(active_space) =
+                space::parse_space(&PathBuf::from(&valid_space_reference.path))
+            {
+                zaku_state.active_space = Some(active_space);
             }
-            None => {}
         }
     }
 
     zaku_state.spacerefs = store::get_spacerefs();
 
-    return ();
+    Ok(())
 }
 
 #[specta::specta]
@@ -623,11 +619,9 @@ pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
                 name: space_config_file.meta.name,
             };
 
-            return Ok(space_reference);
+            Ok(space_reference)
         }
-        Err(err) => {
-            return Err(CmdErr(format!("Unable to parse space: {}", err)));
-        }
+        Err(err) => Err(CmdErr(format!("Unable to parse space: {}", err))),
     }
 }
 
@@ -654,13 +648,13 @@ pub async fn get_space_cookies(
         },
     );
 
-    return Ok(cookies_by_domain);
+    Ok(cookies_by_domain)
 }
 
 #[specta::specta]
 #[tauri::command]
-pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> bool {
-    return SpaceCookies::remove(space_abspath, rm_cookie_dto).is_some();
+pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> CmdResult<bool> {
+    Ok(SpaceCookies::remove(space_abspath, rm_cookie_dto).is_some())
 }
 
 #[specta::specta]
@@ -669,7 +663,7 @@ pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -
     SpaceSettings::persist(space_abspath, &settings)
         .map_err(|err| CmdErr(format!("Failed to persist space settings: {}", err)))?;
 
-    return Ok(());
+    Ok(())
 }
 
 #[specta::specta]
@@ -683,6 +677,8 @@ pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> CmdResult<ZakuSt
 
 #[specta::specta]
 #[tauri::command]
-pub fn show_main_window(window: tauri::Window) {
+pub fn show_main_window(window: tauri::Window) -> CmdResult<()> {
     window.get_webview_window("main").unwrap().show().unwrap();
+
+    Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -389,7 +389,9 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
     })?;
     let space_abspath = active_space.path.as_str();
     let cookie_store = SpaceCookies::load(space_abspath);
-    let space_settings = SpaceSettings::load(space_abspath);
+    let space_settings = SpaceSettings::load(space_abspath).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
     let client = reqwest::Client::builder()
         .cookie_provider(Arc::clone(&cookie_store))
         .build()

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -545,9 +545,13 @@ pub async fn create_space(
         name: create_space_dto.name,
     };
 
-    store::set_active_spaceref(spaceref.clone());
+    store::set_active_spaceref(spaceref.clone()).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
     spacerefs.push(spaceref.clone());
-    store::set_spacerefs(spacerefs.clone());
+    store::set_spacerefs(spacerefs.clone()).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
 
     match space::parse_space(&PathBuf::from(spaceref.clone().path)) {
         Ok(active_space) => {
@@ -582,8 +586,14 @@ pub fn set_active_space(
 
     match space::parse_space(&space_abspath) {
         Ok(space) => {
-            store::set_active_spaceref(space_reference.clone());
-            store::insert_spaceref_if_missing(space_reference.clone());
+            store::set_active_spaceref(space_reference.clone()).map_err(|e| CmdErr::Err {
+                message: e.to_string(),
+            })?;
+            store::insert_spaceref_if_missing(space_reference.clone()).map_err(|e| {
+                CmdErr::Err {
+                    message: e.to_string(),
+                }
+            })?;
 
             zaku_state.active_space = Some(space);
             zaku_state.spacerefs = store::get_spacerefs();
@@ -603,7 +613,9 @@ pub fn remove_space(
     state: tauri::State<Mutex<ZakuState>>,
 ) -> CmdResult<()> {
     let mut zaku_state = state.lock().unwrap();
-    store::remove_spaceref(space_reference);
+    store::remove_spaceref(space_reference).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
 
     let active_space = store::get_active_spaceref();
 
@@ -611,7 +623,9 @@ pub fn remove_space(
         zaku_state.active_space = None;
 
         if let Some(valid_space_reference) = space::first_valid_spaceref() {
-            store::set_active_spaceref(valid_space_reference.clone());
+            store::set_active_spaceref(valid_space_reference.clone()).map_err(|e| CmdErr::Err {
+                message: e.to_string(),
+            })?;
 
             if let Ok(active_space) =
                 space::parse_space(&PathBuf::from(&valid_space_reference.path))

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -388,7 +388,9 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
         message: "No active space".into(),
     })?;
     let space_abspath = active_space.path.as_str();
-    let cookie_store = SpaceCookies::load(space_abspath);
+    let cookie_store = SpaceCookies::load(space_abspath).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
     let space_settings = SpaceSettings::load(space_abspath).map_err(|e| CmdErr::Err {
         message: e.to_string(),
     })?;
@@ -461,7 +463,9 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
         code: Some(status),
     })?;
     let size_bytes = Some(data.len() as u32);
-    SpaceCookies::persist(space_abspath);
+    SpaceCookies::persist(space_abspath).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
 
     Ok(HttpRes {
         status: Some(status),
@@ -644,7 +648,9 @@ pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
 pub async fn get_space_cookies(
     space_abspath: &str,
 ) -> CmdResult<HashMap<String, Vec<SpaceCookie>>> {
-    let cookie_store = SpaceCookies::load(space_abspath);
+    let cookie_store = SpaceCookies::load(space_abspath).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
     let store = cookie_store.lock().map_err(|_| CmdErr::Err {
         message: "Failed to lock the cookie store (CookieStoreLockFailed)".into(),
     })?;
@@ -668,7 +674,11 @@ pub async fn get_space_cookies(
 #[specta::specta]
 #[tauri::command]
 pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> CmdResult<bool> {
-    Ok(SpaceCookies::remove(space_abspath, rm_cookie_dto).is_some())
+    SpaceCookies::remove(space_abspath, rm_cookie_dto)
+        .map(|opt| opt.is_some())
+        .map_err(|e| CmdErr::Err {
+            message: e.to_string(),
+        })
 }
 
 #[specta::specta]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -72,7 +72,7 @@ pub async fn create_collection(
     app_handle: tauri::AppHandle,
 ) -> CmdResult<CreateNewCollection> {
     if create_collection_dto.relpath.is_empty() {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: "Cannot create a collection without name".to_string(),
         });
     };
@@ -113,7 +113,7 @@ pub async fn create_collection(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| CmdErr::Msg {
+                    .map_err(|err| CmdErr::Err {
                     message: format!("Failed to create collection: {}", err),
                 })?;
 
@@ -135,7 +135,7 @@ pub async fn create_collection(
         dir_sanitized_name.as_str(),
     ]);
 
-    fs::create_dir(&dir_abspath).map_err(|err| CmdErr::Msg {
+    fs::create_dir(&dir_abspath).map_err(|err| CmdErr::Err {
         message: format!("Failed to create collection: {}", err),
     })?;
 
@@ -151,7 +151,7 @@ pub async fn create_collection(
 
     zaku_state.active_space =
         Some(
-            space::parse_space(&active_space_abspath).map_err(|err| CmdErr::Msg {
+            space::parse_space(&active_space_abspath).map_err(|err| CmdErr::Err {
                 message: format!(
                     "Failed to parse space after creating the collection: {}",
                     err
@@ -212,7 +212,7 @@ pub fn move_treeitem(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(CmdErr::Msg {
+            return Err(CmdErr::Err {
                 message: format!("Failed to parse space after moving the tree item: {}", err),
             });
         }
@@ -227,7 +227,7 @@ pub fn is_notif_enabled(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .permission_state()
-        .map_err(|err| CmdErr::Msg {
+        .map_err(|err| CmdErr::Err {
             message: format!("Failed to get current permissions state: {}", err),
         })?;
 
@@ -240,7 +240,7 @@ pub fn request_notif_access(app_handle: tauri::AppHandle) -> CmdResult<bool> {
     let permission_state = app_handle
         .notification()
         .request_permission()
-        .map_err(|err| CmdErr::Msg {
+        .map_err(|err| CmdErr::Err {
             message: format!("Failed to request for permissions: {}", err),
         })?;
 
@@ -259,7 +259,7 @@ pub fn dispatch_notif(
         .title(&options.title)
         .body(&options.body)
         .show()
-        .map_err(|err| CmdErr::Msg {
+        .map_err(|err| CmdErr::Err {
             message: format!("Failed to dispatch notification: {}", err),
         })?;
 
@@ -273,7 +273,7 @@ pub async fn create_req(
     app_handle: tauri::AppHandle,
 ) -> CmdResult<CreateNewRequest> {
     if create_req_dto.relpath.is_empty() {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: "Cannot create a request without name".to_string(),
         });
     }
@@ -314,7 +314,7 @@ pub async fn create_req(
 
             let dirs_sanitized_relpath =
                 collection::create_collections_all(&active_space_abspath, &create_collection_dto)
-                    .map_err(|err| CmdErr::Msg {
+                    .map_err(|err| CmdErr::Err {
                     message: format!("Failed to create request's parent directories: {}", err),
                 })?;
 
@@ -336,7 +336,7 @@ pub async fn create_req(
         format!("{}.toml", file_sanitized_name).as_str(),
     ]);
 
-    request::create_reqtoml(&file_abspath, file_display_name).map_err(|err| CmdErr::Msg {
+    request::create_reqtoml(&file_abspath, file_display_name).map_err(|err| CmdErr::Err {
         message: format!("Failed to create request file: {}", err),
     })?;
 
@@ -348,7 +348,7 @@ pub async fn create_req(
     match space::parse_space(&active_space_abspath) {
         Ok(active_space) => zaku_state.active_space = Some(active_space),
         Err(err) => {
-            return Err(CmdErr::Msg {
+            return Err(CmdErr::Err {
                 message: format!("Failed to parse space after creating the request: {}", err),
             });
         }
@@ -384,7 +384,7 @@ pub async fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) -> 
 #[specta::specta]
 #[tauri::command]
 pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<HttpRes> {
-    let active_space = store::get_active_spaceref().ok_or(CmdErr::Msg {
+    let active_space = store::get_active_spaceref().ok_or(CmdErr::Err {
         message: "No active space".into(),
     })?;
     let space_abspath = active_space.path.as_str();
@@ -393,14 +393,14 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
     let client = reqwest::Client::builder()
         .cookie_provider(Arc::clone(&cookie_store))
         .build()
-        .map_err(|e| CmdErr::Msg {
+        .map_err(|e| CmdErr::Err {
             message: e.to_string(),
         })?;
     let cfg = &req.config;
-    let url = cfg.url.raw.clone().ok_or(CmdErr::Msg {
+    let url = cfg.url.raw.clone().ok_or(CmdErr::Err {
         message: "Missing URL".into(),
     })?;
-    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| CmdErr::Msg {
+    let method = reqwest::Method::from_bytes(cfg.method.as_bytes()).map_err(|e| CmdErr::Err {
         message: e.to_string(),
     })?;
     let mut builder = client.request(method, &url);
@@ -429,7 +429,7 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
     }
 
     let start = Instant::now();
-    let resp = builder.send().await.map_err(|e| CmdErr::Msg {
+    let resp = builder.send().await.map_err(|e| CmdErr::Err {
         message: e.to_string(),
     })?;
     if space_settings.notifications.audio.on_req_finish {
@@ -479,7 +479,7 @@ pub async fn create_space(
 ) -> CmdResult<SpaceReference> {
     let location = PathBuf::from(create_space_dto.location.as_str());
     if !location.exists() {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: format!("Location does not exist: {}", create_space_dto.location),
         });
     }
@@ -492,7 +492,7 @@ pub async fn create_space(
         .iter()
         .any(|sr| sr.path == space_abspath.to_string_lossy())
     {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: format!(
                 "Space already exists in saved spaces: {}",
                 space_abspath.to_string_lossy()
@@ -500,7 +500,7 @@ pub async fn create_space(
         });
     }
     if space_abspath.exists() {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: format!(
                 "Directory with this name already exists: {}",
                 space_abspath.to_string_lossy()
@@ -563,7 +563,7 @@ pub fn set_active_space(
     let space_abspath = PathBuf::from(space_reference.path.as_str());
 
     if !space_abspath.exists() {
-        return Err(CmdErr::Msg {
+        return Err(CmdErr::Err {
             message: format!(
                 "Directory does not exist: {}",
                 space_abspath.to_string_lossy()
@@ -581,7 +581,7 @@ pub fn set_active_space(
 
             Ok(())
         }
-        Err(err) => Err(CmdErr::Msg {
+        Err(err) => Err(CmdErr::Err {
             message: format!("Unable to parse space: {}", err),
         }),
     }
@@ -631,7 +631,7 @@ pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
 
             Ok(space_reference)
         }
-        Err(err) => Err(CmdErr::Msg {
+        Err(err) => Err(CmdErr::Err {
             message: format!("Unable to parse space: {}", err),
         }),
     }
@@ -643,7 +643,7 @@ pub async fn get_space_cookies(
     space_abspath: &str,
 ) -> CmdResult<HashMap<String, Vec<SpaceCookie>>> {
     let cookie_store = SpaceCookies::load(space_abspath);
-    let store = cookie_store.lock().map_err(|_| CmdErr::Msg {
+    let store = cookie_store.lock().map_err(|_| CmdErr::Err {
         message: "Failed to lock the cookie store (CookieStoreLockFailed)".into(),
     })?;
 
@@ -672,7 +672,7 @@ pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> Cmd
 #[specta::specta]
 #[tauri::command]
 pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -> CmdResult<()> {
-    SpaceSettings::persist(space_abspath, &settings).map_err(|err| CmdErr::Msg {
+    SpaceSettings::persist(space_abspath, &settings).map_err(|err| CmdErr::Err {
         message: format!("Failed to persist space settings: {}", err),
     })?;
 
@@ -684,7 +684,7 @@ pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -
 pub fn get_zaku_state(state: tauri::State<Mutex<ZakuState>>) -> CmdResult<ZakuState> {
     match state.lock() {
         Ok(zaku_state) => Ok(zaku_state.clone()),
-        Err(e) => Err(CmdErr::Msg {
+        Err(e) => Err(CmdErr::Err {
             message: format!("State lock error: {}", e),
         }),
     }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -366,7 +366,10 @@ pub async fn persist_to_reqbuf(
 ) -> CmdResult<()> {
     let abs = Path::new(space_abspath);
     let rel = Path::new(relpath);
-    buffer::persist_req_to_spacebuf(abs, rel, request);
+
+    buffer::persist_req_to_spacebuf(abs, rel, request).map_err(|e| CmdErr::Err {
+        message: e.to_string(),
+    })?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -43,7 +43,7 @@ pub mod models;
 
 pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
     tauri_specta::collect_commands![
-        get_sharedstate,
+        get_shared_state,
         create_space,
         set_active_space,
         remove_space,
@@ -710,7 +710,7 @@ pub async fn save_space_settings(space_abspath: &str, settings: SpaceSettings) -
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_sharedstate(
+pub fn get_shared_state(
     sharedstate_mtx: tauri::State<Mutex<SharedState>>,
 ) -> CmdResult<SharedState> {
     match sharedstate_mtx.lock() {

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -2,17 +2,6 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
-pub struct CmdErr(pub String);
-
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
-pub struct CmdHttpErr {
-    pub message: String,
-    pub code: Option<u16>,
-}
-
-pub type CmdResult<T, E = CmdErr> = Result<T, E>;
-
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct OpenDirDialogOpt {
     pub title: Option<String>,
 }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -2,6 +2,17 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct CmdErr(pub String);
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct CmdHttpErr {
+    pub message: String,
+    pub code: Option<u16>,
+}
+
+pub type CmdResult<T, E = CmdErr> = Result<T, E>;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct OpenDirDialogOpt {
     pub title: Option<String>,
 }

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -38,7 +38,10 @@ pub enum Error {
     Time(time::error::Error),
 
     #[from]
-    Rodio(rodio::StreamError),
+    RodioStream(rodio::StreamError),
+
+    #[from]
+    RodioPlay(rodio::PlayError),
 
     #[from]
     CookieStore(cookie_store::Error),

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -11,6 +11,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     FileNotFound(String),
     FileReadError(String),
+    LockError(String),
 
     #[from]
     Io(io::Error),

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -42,6 +42,9 @@ pub enum Error {
 
     #[from]
     CookieStore(cookie_store::Error),
+
+    #[from]
+    ShortcutPlugin(tauri_plugin_global_shortcut::Error),
 }
 
 impl fmt::Display for Error {

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -52,8 +52,10 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(tag = "type")]
+#[specta(tag = "type")]
 pub enum CmdErr {
-    Msg { message: String },
+    Err { message: String },
     Http { message: String, code: Option<u16> },
 }
 

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -1,4 +1,7 @@
 use derive_more::From;
+use serde::Deserialize;
+use serde::Serialize;
+use specta::Type;
 use std::fmt;
 use std::io;
 
@@ -47,3 +50,11 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub enum CmdErr {
+    Msg { message: String },
+    Http { message: String, code: Option<u16> },
+}
+
+pub type CmdResult<T> = core::result::Result<T, CmdErr>;

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -1,8 +1,49 @@
-use serde::{Deserialize, Serialize};
-use specta::Type;
+use derive_more::From;
+use std::fmt;
+use std::io;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
-pub struct ZakuError {
-    pub error: String,
-    pub message: String,
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[derive(Debug, From)]
+pub enum Error {
+    FileNotFound(String),
+    FileReadError(String),
+
+    #[from]
+    Io(io::Error),
+
+    #[from]
+    SerdeJson(serde_json::Error),
+
+    #[from]
+    Tauri(tauri::Error),
+
+    #[from]
+    Url(url::ParseError),
+
+    #[from]
+    Reqwest(reqwest::Error),
+
+    #[from]
+    TomlDe(toml::de::Error),
+
+    #[from]
+    TomlSer(toml::ser::Error),
+
+    #[from]
+    Time(time::error::Error),
+
+    #[from]
+    Rodio(rodio::StreamError),
+
+    #[from]
+    CookieStore(cookie_store::Error),
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
 
 fn main() {
     #[cfg(target_os = "linux")]
-    platform::linux::initialize()?;
+    platform::linux::initialize().expect("Failed to initialize Linux platform");
 
     let builder = tauri_specta::Builder::<tauri::Wry>::new()
         .commands(commands::collect())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ pub mod utils;
 
 use crate::state::ZakuState;
 
-const TS_BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
+const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
 
 fn main() {
     #[cfg(target_os = "linux")]
@@ -32,7 +32,7 @@ fn main() {
         builder
             .export(
                 Typescript::default().formatter(formatter::prettier),
-                TS_BINDINGS_PATH,
+                BINDINGS_PATH,
             )
             .expect("Failed to export typescript bindings");
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
 
 fn main() {
     #[cfg(target_os = "linux")]
-    platform::linux::initialize();
+    platform::linux::initialize()?;
 
     let builder = tauri_specta::Builder::<tauri::Wry>::new()
         .commands(commands::collect())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
             state::initialize(app);
             shortcuts::initialize(app);
 
-            return Ok(());
+            Ok(())
         })
         .invoke_handler(builder.invoke_handler());
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
-            state::initialize(app);
+            state::initialize(app)?;
             shortcuts::initialize(app);
 
             Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             state::initialize(app)?;
-            shortcuts::initialize(app);
+            shortcuts::initialize(app)?;
 
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,25 +16,25 @@ pub mod utils;
 
 use crate::state::ZakuState;
 
+const TS_BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
+
 fn main() {
     #[cfg(target_os = "linux")]
     platform::linux::initialize();
 
-    let builder = tauri_specta::Builder::<tauri::Wry>::new().commands(commands::collect());
+    let builder = tauri_specta::Builder::<tauri::Wry>::new()
+        .commands(commands::collect())
+        .error_handling(tauri_specta::ErrorHandlingMode::Result);
 
     if std::env::var("GEN_BINDINGS").is_ok() {
-        use specta_typescript::Typescript;
-        use std::process::Command;
+        use specta_typescript::{formatter, Typescript};
 
         builder
-            .export(Typescript::default(), "./../src/lib/bindings.ts")
+            .export(
+                Typescript::default().formatter(formatter::prettier),
+                TS_BINDINGS_PATH,
+            )
             .expect("Failed to export typescript bindings");
-
-        Command::new("pnpm")
-            .arg("format")
-            .current_dir("./../src")
-            .status()
-            .expect("Failed to execute pnpm format");
     }
 
     let app = tauri::Builder::default()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
 
 fn main() {
     #[cfg(target_os = "linux")]
-    platform::linux::initialize().expect("Failed to initialize Linux platform");
+    platform::linux::initialize().expect("Failed to initialize linux platform");
 
     let builder = tauri_specta::Builder::<tauri::Wry>::new()
         .commands(commands::collect())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ pub mod state;
 pub mod store;
 pub mod utils;
 
-use crate::state::ZakuState;
+use crate::state::SharedState;
 
 const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
 
@@ -38,7 +38,7 @@ fn main() {
     }
 
     let app = tauri::Builder::default()
-        .manage(Mutex::new(ZakuState {
+        .manage(Mutex::new(SharedState {
             active_space: None,
             spacerefs: Vec::new(),
         }))

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -35,5 +35,5 @@ pub fn play_finish(app_handle: &AppHandle) -> Result<(), std::io::Error> {
     sink.append(source);
     sink.sleep_until_end();
 
-    return Ok(());
+    Ok(())
 }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -2,35 +2,18 @@ use rodio::{Decoder, OutputStream, Sink};
 use std::{fs::File, io::BufReader};
 use tauri::{path::BaseDirectory, AppHandle, Manager};
 
-pub fn play_finish(app_handle: &AppHandle) -> Result<(), std::io::Error> {
-    let (_stream, stream_handle) = OutputStream::try_default().map_err(|err| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Audio stream error: {}", err),
-        )
-    })?;
-    let sink = Sink::try_new(&stream_handle).map_err(|err| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Sink creation error: {}", err),
-        )
-    })?;
+use crate::error::{Error, Result};
+
+pub fn play_finish(app_handle: &AppHandle) -> Result<()> {
+    let (_stream, stream_handle) = OutputStream::try_default()?;
+    let sink = Sink::try_new(&stream_handle)?;
     let sound_filepath = app_handle
         .path()
         .resolve("assets/sounds/glass.wav", BaseDirectory::Resource)
-        .map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Path resolution error: {}", err),
-            )
-        })?;
+        .map_err(|e| Error::FileNotFound(e.to_string()))?;
     let sound_file = File::open(sound_filepath)?;
-    let source = Decoder::new(BufReader::new(sound_file)).map_err(|err| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Audio decode error: {}", err),
-        )
-    })?;
+    let source = Decoder::new(BufReader::new(sound_file))
+        .map_err(|e| Error::FileReadError(e.to_string()))?;
 
     sink.append(source);
     sink.sleep_until_end();

--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -9,10 +9,14 @@ use {
     },
 };
 
-pub fn initialize() {
+use crate::error::Result;
+
+pub fn initialize() -> Result<()> {
     if has_nvidia_gpu() {
         env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1"); // https://github.com/tauri-apps/tauri/issues/9304
     }
+
+    Ok(())
 }
 
 fn has_nvidia_gpu() -> bool {

--- a/src-tauri/src/request/mod.rs
+++ b/src-tauri/src/request/mod.rs
@@ -9,7 +9,7 @@ use crate::request::models::{ReqToml, ReqTomlConfig, ReqTomlMeta};
 pub mod models;
 
 pub fn create_reqtoml(abspath: &Path, display_name: &str) -> Result<()> {
-    let mut reqtoml_file = File::create_new(&abspath.with_extension("toml"))?;
+    let mut reqtoml_file = File::create_new(abspath.with_extension("toml"))?;
 
     let req_toml = ReqToml {
         meta: ReqTomlMeta {
@@ -47,5 +47,5 @@ pub fn persist_reqtoml(req_abspath: &Path, req_toml: &ReqToml) -> Result<()> {
     let toml_str = toml::to_string_pretty(&req_toml)?;
     fs::write(req_abspath, toml_str)?;
 
-    return Ok(());
+    Ok(())
 }

--- a/src-tauri/src/request/mod.rs
+++ b/src-tauri/src/request/mod.rs
@@ -1,19 +1,15 @@
 use std::fs::{self, File};
-use std::io::{Error, ErrorKind, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use toml;
 
+use crate::error::{Error, Result};
 use crate::request::models::{ReqToml, ReqTomlConfig, ReqTomlMeta};
 
 pub mod models;
 
-pub fn create_reqtoml(abspath: &Path, display_name: &str) -> Result<(), Error> {
-    let mut reqtoml_file = File::create_new(&abspath.with_extension("toml")).map_err(|err| {
-        Error::new(
-            ErrorKind::Other,
-            format!("Failed to create request file: {}", err),
-        )
-    })?;
+pub fn create_reqtoml(abspath: &Path, display_name: &str) -> Result<()> {
+    let mut reqtoml_file = File::create_new(&abspath.with_extension("toml"))?;
 
     let req_toml = ReqToml {
         meta: ReqTomlMeta {
@@ -29,57 +25,27 @@ pub fn create_reqtoml(abspath: &Path, display_name: &str) -> Result<(), Error> {
         },
     };
 
-    let toml_str = toml::to_string_pretty(&req_toml).map_err(|err| {
-        Error::new(
-            ErrorKind::Other,
-            format!("Failed to serialize request file: {}", err),
-        )
-    })?;
+    let toml_str = toml::to_string_pretty(&req_toml)?;
 
-    reqtoml_file.write_all(toml_str.as_bytes()).map_err(|err| {
-        Error::new(
-            ErrorKind::Other,
-            format!("Failed to write to request file: {}", err),
-        )
-    })?;
+    reqtoml_file.write_all(toml_str.as_bytes())?;
 
-    return Ok(());
+    Ok(())
 }
 
-pub fn parse_reqtoml(abspath: &PathBuf) -> Result<ReqToml, Error> {
-    let toml_str = match fs::read_to_string(abspath) {
-        Ok(toml_str) => toml_str,
-        Err(err) => {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                format!("Failed to load {}: {}", abspath.display(), err),
-            ));
-        }
-    };
+pub fn parse_reqtoml(abspath: &PathBuf) -> Result<ReqToml> {
+    let toml_str = std::fs::read_to_string(abspath)?;
+    let req_toml = toml::from_str(&toml_str)?;
 
-    let req_toml = match toml::from_str(&toml_str) {
-        Ok(req_toml) => req_toml,
-        Err(err) => {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Failed to parse {}: {}", abspath.display(), err),
-            ));
-        }
-    };
-
-    return Ok(req_toml);
+    Ok(req_toml)
 }
 
-pub fn persist_reqtoml(req_abspath: &Path, req_toml: &ReqToml) -> Result<(), Error> {
+pub fn persist_reqtoml(req_abspath: &Path, req_toml: &ReqToml) -> Result<()> {
     if !req_abspath.exists() {
-        return Err(Error::new(
-            ErrorKind::NotFound,
-            format!("Request file does not exist: {:?}", req_abspath),
-        ));
+        return Err(Error::FileNotFound(req_abspath.display().to_string()));
     }
 
-    let toml_str = toml::to_string_pretty(&req_toml).unwrap();
-    fs::write(req_abspath, toml_str).unwrap();
+    let toml_str = toml::to_string_pretty(&req_toml)?;
+    fs::write(req_abspath, toml_str)?;
 
     return Ok(());
 }

--- a/src-tauri/src/request/models.rs
+++ b/src-tauri/src/request/models.rs
@@ -175,12 +175,6 @@ pub struct CreateRequestDto {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
-pub struct HttpErr {
-    pub message: String,
-    pub code: Option<u16>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct HttpRes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<u16>,

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -17,41 +17,41 @@ pub fn initialize(app: &mut tauri::App) -> Result<()> {
         #[cfg(target_os = "linux")]
         let shortcuts = ["Control+Shift+I", "Command+Option+I"];
 
-        app.handle().plugin(
-            tauri_plugin_global_shortcut::Builder::new()
-                .with_shortcuts(shortcuts)?
-                .with_handler(|handler_app, shortcut, event| {
-                    if event.state == ShortcutState::Pressed {
-                        match shortcut_combination(shortcut) {
-                            #[cfg(target_os = "macos")]
-                            Some(ShortcutCombination::CommandOptionI) => {
-                                utils::toggle_devtools(handler_app.app_handle());
-                            }
-                            #[cfg(target_os = "macos")]
-                            Some(ShortcutCombination::ControlShiftI) => {}
-
-                            #[cfg(target_os = "windows")]
-                            Some(ShortcutCombination::ControlShiftI) => {
-                                utils::toggle_devtools(handler_app.app_handle());
-                            }
-                            #[cfg(target_os = "windows")]
-                            Some(ShortcutCombination::CommandOptionI) => {}
-
-                            #[cfg(target_os = "linux")]
-                            Some(ShortcutCombination::ControlShiftI) => {
-                                utils::toggle_devtools(handler_app.app_handle());
-                            }
-                            #[cfg(target_os = "linux")]
-                            Some(ShortcutCombination::CommandOptionI) => {
-                                utils::toggle_devtools(handler_app.app_handle());
-                            }
-
-                            None => {}
+        let global_shortcuts = tauri_plugin_global_shortcut::Builder::new()
+            .with_shortcuts(shortcuts)?
+            .with_handler(|handler_app, shortcut, event| {
+                if event.state == ShortcutState::Pressed {
+                    match shortcut_combination(shortcut) {
+                        #[cfg(target_os = "macos")]
+                        Some(ShortcutCombination::CommandOptionI) => {
+                            utils::toggle_devtools(handler_app.app_handle());
                         }
+                        #[cfg(target_os = "macos")]
+                        Some(ShortcutCombination::ControlShiftI) => {}
+
+                        #[cfg(target_os = "windows")]
+                        Some(ShortcutCombination::ControlShiftI) => {
+                            utils::toggle_devtools(handler_app.app_handle());
+                        }
+                        #[cfg(target_os = "windows")]
+                        Some(ShortcutCombination::CommandOptionI) => {}
+
+                        #[cfg(target_os = "linux")]
+                        Some(ShortcutCombination::ControlShiftI) => {
+                            utils::toggle_devtools(handler_app.app_handle());
+                        }
+                        #[cfg(target_os = "linux")]
+                        Some(ShortcutCombination::CommandOptionI) => {
+                            utils::toggle_devtools(handler_app.app_handle());
+                        }
+
+                        None => {}
                     }
-                })
-                .build(),
-        )?
+                }
+            })
+            .build();
+
+        app.handle().plugin(global_shortcuts)?
     }
 
     Ok(())

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,9 +1,9 @@
 use tauri::Manager;
-use tauri_plugin_global_shortcut::{Code, Modifiers};
+use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut};
 
-use crate::utils;
+use crate::{error::Result, utils};
 
-pub fn initialize(app: &mut tauri::App) {
+pub fn initialize(app: &mut tauri::App) -> Result<()> {
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     {
         use tauri_plugin_global_shortcut::ShortcutState;
@@ -17,45 +17,44 @@ pub fn initialize(app: &mut tauri::App) {
         #[cfg(target_os = "linux")]
         let shortcuts = ["Control+Shift+I", "Command+Option+I"];
 
-        app.handle()
-            .plugin(
-                tauri_plugin_global_shortcut::Builder::new()
-                    .with_shortcuts(shortcuts)
-                    .unwrap()
-                    .with_handler(|handler_app, shortcut, event| {
-                        if event.state == ShortcutState::Pressed {
-                            match shortcut_combination(shortcut) {
-                                #[cfg(target_os = "macos")]
-                                Some(ShortcutCombination::CommandOptionI) => {
-                                    utils::toggle_devtools(handler_app.app_handle());
-                                }
-                                #[cfg(target_os = "macos")]
-                                Some(ShortcutCombination::ControlShiftI) => {}
-
-                                #[cfg(target_os = "windows")]
-                                Some(ShortcutCombination::ControlShiftI) => {
-                                    utils::toggle_devtools(handler_app.app_handle());
-                                }
-                                #[cfg(target_os = "windows")]
-                                Some(ShortcutCombination::CommandOptionI) => {}
-
-                                #[cfg(target_os = "linux")]
-                                Some(ShortcutCombination::ControlShiftI) => {
-                                    utils::toggle_devtools(handler_app.app_handle());
-                                }
-                                #[cfg(target_os = "linux")]
-                                Some(ShortcutCombination::CommandOptionI) => {
-                                    utils::toggle_devtools(handler_app.app_handle());
-                                }
-
-                                None => {}
+        app.handle().plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_shortcuts(shortcuts)?
+                .with_handler(|handler_app, shortcut, event| {
+                    if event.state == ShortcutState::Pressed {
+                        match shortcut_combination(shortcut) {
+                            #[cfg(target_os = "macos")]
+                            Some(ShortcutCombination::CommandOptionI) => {
+                                utils::toggle_devtools(handler_app.app_handle());
                             }
+                            #[cfg(target_os = "macos")]
+                            Some(ShortcutCombination::ControlShiftI) => {}
+
+                            #[cfg(target_os = "windows")]
+                            Some(ShortcutCombination::ControlShiftI) => {
+                                utils::toggle_devtools(handler_app.app_handle());
+                            }
+                            #[cfg(target_os = "windows")]
+                            Some(ShortcutCombination::CommandOptionI) => {}
+
+                            #[cfg(target_os = "linux")]
+                            Some(ShortcutCombination::ControlShiftI) => {
+                                utils::toggle_devtools(handler_app.app_handle());
+                            }
+                            #[cfg(target_os = "linux")]
+                            Some(ShortcutCombination::CommandOptionI) => {
+                                utils::toggle_devtools(handler_app.app_handle());
+                            }
+
+                            None => {}
                         }
-                    })
-                    .build(),
-            )
-            .unwrap();
+                    }
+                })
+                .build(),
+        )?
     }
+
+    Ok(())
 }
 
 pub enum ShortcutCombination {
@@ -63,9 +62,7 @@ pub enum ShortcutCombination {
     ControlShiftI,
 }
 
-pub fn shortcut_combination(
-    shortcut: &tauri_plugin_global_shortcut::Shortcut,
-) -> Option<ShortcutCombination> {
+pub fn shortcut_combination(shortcut: &Shortcut) -> Option<ShortcutCombination> {
     let modifiers = shortcut.mods;
     let code = shortcut.key;
 
@@ -80,6 +77,6 @@ pub fn shortcut_combination(
     {
         Some(ShortcutCombination::ControlShiftI)
     } else {
-        return None;
+        None
     }
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -73,12 +73,12 @@ pub fn shortcut_combination(
         && modifiers.contains(Modifiers::ALT)
         && code == Code::KeyI
     {
-        return Some(ShortcutCombination::CommandOptionI);
+        Some(ShortcutCombination::CommandOptionI)
     } else if modifiers.contains(Modifiers::CONTROL)
         && modifiers.contains(Modifiers::SHIFT)
         && code == Code::KeyI
     {
-        return Some(ShortcutCombination::ControlShiftI);
+        Some(ShortcutCombination::ControlShiftI)
     } else {
         return None;
     }

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -128,9 +128,8 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
                                     .requests
                                     .push(HttpReq::from_reqtoml(&req_toml, file_name));
                             }
-                            Err(err) => {
-                                eprintln!("{}", err);
-                                eprintln!("Unable to parse the request file")
+                            Err(_) => {
+                                eprintln!("Invalid request TOML: '{}'", entry_abspath.display(),);
                             }
                         }
                     }

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::vec::IntoIter;
@@ -9,6 +8,8 @@ use std::vec::IntoIter;
 use crate::{
     collection,
     collection::models::{Collection, CollectionMeta},
+    error::Error,
+    error::Result,
     request,
     request::models::HttpReq,
     space::models::{Space, SpaceConfigFile, SpaceCookie, SpaceReference},
@@ -25,7 +26,7 @@ pub struct CollectionRcRefCell {
     pub collections: Vec<Rc<RefCell<CollectionRcRefCell>>>,
 }
 
-fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
+fn parse_root_collection(space_abspath: &Path) -> Result<Collection> {
     let space_dirname = space_abspath
         .file_name()
         .unwrap_or_else(|| space_abspath.as_os_str())
@@ -102,6 +103,10 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
                         .collections
                         .push(sub_collection);
                 } else if entry_abspath.is_file() {
+                    if entry_abspath.extension().and_then(|e| e.to_str()) != Some("toml") {
+                        continue;
+                    }
+
                     let relpath = entry_abspath
                         .strip_prefix(space_abspath)
                         .unwrap()
@@ -129,7 +134,7 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
                                     .push(HttpReq::from_reqtoml(&req_toml, file_name));
                             }
                             Err(_) => {
-                                eprintln!("Invalid request TOML: '{}'", entry_abspath.display(),);
+                                eprintln!("Invalid request TOML: '{}'", entry_abspath.display());
                             }
                         }
                     }
@@ -186,71 +191,44 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
         }
     }
 
-    match root_collection {
-        Some(collection) => Ok(collection),
-        None => Err(Error::new(
-            ErrorKind::NotFound,
-            "Failed to build collection, stack is empty no collection to return",
-        )),
-    }
+    root_collection
+        .ok_or_else(|| Error::FileReadError("Failed to build collection: empty stack".to_string()))
 }
 
-pub fn parse_space(space_abspath: &Path) -> Result<Space, Error> {
-    match parse_root_collection(space_abspath) {
-        Ok(root_collection) => match parse_spacecfg(&space_abspath) {
-            Ok(space_config_file) => {
-                let cookie_store = SpaceCookies::load(space_abspath.to_string_lossy().as_ref());
-                let store = cookie_store.lock().unwrap();
-                let cookies: Vec<SpaceCookie> = store
-                    .iter_any()
-                    .map(SpaceCookie::from_cookie_store)
-                    .collect();
-                let cookies_by_domain: HashMap<String, Vec<SpaceCookie>> =
-                    cookies.into_iter().fold(
-                        HashMap::new(),
-                        |mut acc: HashMap<String, Vec<SpaceCookie>>, ck| {
-                            acc.entry(ck.domain.clone()).or_default().push(ck);
-                            acc
-                        },
-                    );
-                let settings = SpaceSettings::load(space_abspath.to_string_lossy().as_ref());
-
-                Ok(Space {
-                    abspath: space_abspath.to_string_lossy().into_owned(),
-                    meta: space_config_file.meta,
-                    root: root_collection,
-                    cookies: cookies_by_domain,
-                    settings,
-                })
-            }
-            Err(err) => {
-                eprintln!("{}", err);
-                return Err(err);
-            }
-        },
-        Err(err) => {
-            eprintln!("{}", err);
-            return Err(err);
-        }
-    }
-}
-
-pub fn parse_spacecfg(space_abspath: &Path) -> Result<SpaceConfigFile, Error> {
-    return fs::read_to_string(space_abspath.join(".zaku/config.toml"))
-        .map_err(|err| {
-            Error::new(
-                ErrorKind::NotFound,
-                format!("Failed to load {}: {}", space_abspath.display(), err),
-            )
-        })
-        .and_then(|content| {
-            toml::from_str(&content).map_err(|err| {
-                Error::new(
-                    ErrorKind::InvalidData,
-                    format!("Failed to parse {}: {}", space_abspath.display(), err),
-                )
-            })
+pub fn parse_space(space_abspath: &Path) -> Result<Space> {
+    let root_collection = parse_root_collection(space_abspath)?;
+    let space_config_file = parse_spacecfg(space_abspath)?;
+    let cookie_store = SpaceCookies::load(space_abspath.to_string_lossy().as_ref());
+    let store = cookie_store.lock().unwrap();
+    let cookies: Vec<SpaceCookie> = store
+        .iter_any()
+        .map(SpaceCookie::from_cookie_store)
+        .collect();
+    let cookies_by_domain: HashMap<String, Vec<SpaceCookie>> =
+        cookies.into_iter().fold(HashMap::new(), |mut acc, ck| {
+            acc.entry(ck.domain.clone()).or_default().push(ck);
+            acc
         });
+
+    let settings = SpaceSettings::load(&space_abspath.to_string_lossy())?;
+
+    Ok(Space {
+        abspath: space_abspath.to_string_lossy().into_owned(),
+        meta: space_config_file.meta,
+        root: root_collection,
+        cookies: cookies_by_domain,
+        settings,
+    })
+}
+
+pub fn parse_spacecfg(space_abspath: &Path) -> Result<SpaceConfigFile> {
+    let path = space_abspath.join(".zaku/config.toml");
+    let content =
+        fs::read_to_string(&path).map_err(|_| Error::FileNotFound(path.display().to_string()))?;
+    let config = toml::from_str(&content)
+        .map_err(|e| Error::FileReadError(format!("{}: {}", path.display(), e)))?;
+
+    Ok(config)
 }
 
 pub fn first_valid_spaceref() -> Option<SpaceReference> {

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -178,27 +178,20 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection, Error> {
 
             let sub_collections_iter = sub_collection_ref_cell.collections.clone().into_iter();
             stack.push((sub_collection, sub_collections_iter));
+        } else if let Some((mut parent_collection, parent_sub_collections_iter)) = stack.pop() {
+            parent_collection.collections.push(cur_collection);
+            stack.push((parent_collection, parent_sub_collections_iter));
         } else {
-            if let Some((mut parent_collection, parent_sub_collections_iter)) = stack.pop() {
-                parent_collection.collections.push(cur_collection);
-
-                stack.push((parent_collection, parent_sub_collections_iter));
-            } else {
-                root_collection = Some(cur_collection);
-            }
+            root_collection = Some(cur_collection);
         }
     }
 
     match root_collection {
-        Some(collection) => {
-            return Ok(collection);
-        }
-        None => {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                "Failed to build collection, stack is empty no collection to return",
-            ));
-        }
+        Some(collection) => Ok(collection),
+        None => Err(Error::new(
+            ErrorKind::NotFound,
+            "Failed to build collection, stack is empty no collection to return",
+        )),
     }
 }
 
@@ -222,13 +215,13 @@ pub fn parse_space(space_abspath: &Path) -> Result<Space, Error> {
                     );
                 let settings = SpaceSettings::load(space_abspath.to_string_lossy().as_ref());
 
-                return Ok(Space {
+                Ok(Space {
                     abspath: space_abspath.to_string_lossy().into_owned(),
                     meta: space_config_file.meta,
                     root: root_collection,
                     cookies: cookies_by_domain,
                     settings,
-                });
+                })
             }
             Err(err) => {
                 eprintln!("{}", err);

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -14,7 +14,8 @@ use crate::{
     request::models::HttpReq,
     space::models::{Space, SpaceConfigFile, SpaceCookie, SpaceReference},
     store,
-    store::models::{SpaceBuf, SpaceCookies, SpaceSettings},
+    store::models::{SpaceCookies, SpaceSettings},
+    store::spaces::buffer::SpaceBuf,
 };
 
 pub mod models;
@@ -35,8 +36,10 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection> {
     let relative_space_root = "".to_string();
     let collection_name_by_relpath =
         collection::displayname_by_relpath(space_abspath).unwrap_or_else(|_| HashMap::new());
-    let active_space_buffer = SpaceBuf::load(space_abspath);
-    let active_spacebuf_rlock = SpaceBuf::acq_rlock(&active_space_buffer);
+    let active_space_buffer = SpaceBuf::load(space_abspath)?;
+    let active_spacebuf_rlock = active_space_buffer
+        .read()
+        .map_err(|_| Error::LockError("Failed to acquire read lock".into()))?;
     let space_config = match parse_spacecfg(&space_abspath) {
         Ok(space_config) => Some(space_config),
         Err(_) => None,

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -198,7 +198,7 @@ fn parse_root_collection(space_abspath: &Path) -> Result<Collection> {
 pub fn parse_space(space_abspath: &Path) -> Result<Space> {
     let root_collection = parse_root_collection(space_abspath)?;
     let space_config_file = parse_spacecfg(space_abspath)?;
-    let cookie_store = SpaceCookies::load(space_abspath.to_string_lossy().as_ref());
+    let cookie_store = SpaceCookies::load(space_abspath.to_string_lossy().as_ref())?;
     let store = cookie_store.lock().unwrap();
     let cookies: Vec<SpaceCookie> = store
         .iter_any()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use tauri::{App, Manager};
 
 use crate::{
+    error::Result,
     space::{
         self,
         models::{Space, SpaceReference},
@@ -18,7 +19,7 @@ pub struct ZakuState {
     pub spacerefs: Vec<SpaceReference>,
 }
 
-pub fn initialize(app: &mut App) {
+pub fn initialize(app: &mut App) -> Result<()> {
     let active_spaceref = store::get_active_spaceref().or_else(|| space::first_valid_spaceref());
     let spacerefs = store::get_spacerefs();
     let state = app.app_handle().state::<Mutex<ZakuState>>();
@@ -27,29 +28,30 @@ pub fn initialize(app: &mut App) {
     if let Some(active_spaceref) = active_spaceref {
         let active_spacepath = PathBuf::from(active_spaceref.path);
 
-        match space::parse_space(&active_spacepath) {
-            Ok(active_space) => {
+        space::parse_space(&active_spacepath)
+            .map(|active_space| {
                 zaku_state.active_space = Some(active_space);
-            }
-            Err(_) => match space::first_valid_spaceref() {
-                Some(valid_space_reference) => {
-                    store::set_active_spaceref(valid_space_reference.clone());
+            })
+            .or_else(|_| {
+                if let Some(valid_space_reference) = space::first_valid_spaceref() {
+                    store::set_active_spaceref(valid_space_reference.clone())?;
 
-                    let valid_space_path = PathBuf::from(valid_space_reference.path);
-
-                    match space::parse_space(&valid_space_path) {
-                        Ok(valid_space) => {
+                    let valid_space_path = PathBuf::from(&valid_space_reference.path);
+                    space::parse_space(&valid_space_path)
+                        .map(|valid_space| {
                             zaku_state.active_space = Some(valid_space);
-                        }
-                        Err(err) => {
-                            eprintln!("Error parsing space: {}", err);
-                        }
-                    }
+                        })
+                        .map_err(|e| {
+                            eprintln!("Error parsing space: {}", e);
+                            e
+                        })
+                } else {
+                    Ok(())
                 }
-                None => {}
-            },
-        };
+            })?;
     }
 
     zaku_state.spacerefs = spacerefs;
+
+    Ok(())
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
-pub struct ZakuState {
+pub struct SharedState {
     pub active_space: Option<Space>,
     pub spacerefs: Vec<SpaceReference>,
 }
@@ -22,15 +22,15 @@ pub struct ZakuState {
 pub fn initialize(app: &mut App) -> Result<()> {
     let active_spaceref = store::get_active_spaceref().or_else(|| space::first_valid_spaceref());
     let spacerefs = store::get_spacerefs();
-    let state = app.app_handle().state::<Mutex<ZakuState>>();
-    let mut zaku_state = state.lock().unwrap();
+    let sharedstate_mtx = app.app_handle().state::<Mutex<SharedState>>();
+    let mut sharedstate = sharedstate_mtx.lock().unwrap();
 
     if let Some(active_spaceref) = active_spaceref {
         let active_spacepath = PathBuf::from(active_spaceref.path);
 
         space::parse_space(&active_spacepath)
             .map(|active_space| {
-                zaku_state.active_space = Some(active_space);
+                sharedstate.active_space = Some(active_space);
             })
             .or_else(|_| {
                 if let Some(valid_space_reference) = space::first_valid_spaceref() {
@@ -39,7 +39,7 @@ pub fn initialize(app: &mut App) -> Result<()> {
                     let valid_space_path = PathBuf::from(&valid_space_reference.path);
                     space::parse_space(&valid_space_path)
                         .map(|valid_space| {
-                            zaku_state.active_space = Some(valid_space);
+                            sharedstate.active_space = Some(valid_space);
                         })
                         .map_err(|e| {
                             eprintln!("Error parsing space: {}", e);
@@ -51,7 +51,7 @@ pub fn initialize(app: &mut App) -> Result<()> {
             })?;
     }
 
-    zaku_state.spacerefs = spacerefs;
+    sharedstate.spacerefs = spacerefs;
 
     Ok(())
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -52,6 +52,4 @@ pub fn initialize(app: &mut App) {
     }
 
     zaku_state.spacerefs = spacerefs;
-
-    return ();
 }

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -6,25 +6,25 @@ use std::sync::RwLock;
 use crate::{
     error::{Error, Result},
     space::models::SpaceReference,
-    store::models::ZakuStore,
+    store::models::AppStore,
 };
 
 pub mod models;
 pub mod spaces;
 
-pub static STORE_ABSPATH: Lazy<PathBuf> = Lazy::new(|| {
+pub static APP_STORE_ABSPATH: Lazy<PathBuf> = Lazy::new(|| {
     dirs::data_dir()
         .expect("Unable to get data directory")
         .join("Zaku/store")
         .with_extension("json")
 });
 
-static ZAKU_STORE: Lazy<RwLock<ZakuStore>> = Lazy::new(|| match ZakuStore::load(&STORE_ABSPATH) {
+static APP_STORE: Lazy<RwLock<AppStore>> = Lazy::new(|| match AppStore::load(&APP_STORE_ABSPATH) {
     Ok(store) => RwLock::new(store),
-    Err(_) => RwLock::new(ZakuStore::default()),
+    Err(_) => RwLock::new(AppStore::default()),
 });
 
-impl ZakuStore {
+impl AppStore {
     fn load(path: &Path) -> Result<Self> {
         let content = fs::read_to_string(path)
             .map_err(|_| Error::FileReadError("Failed to read store file".into()))?;
@@ -34,76 +34,76 @@ impl ZakuStore {
     }
 
     fn persist(&self) -> Result<()> {
-        if let Some(parent) = STORE_ABSPATH.parent() {
+        if let Some(parent) = APP_STORE_ABSPATH.parent() {
             fs::create_dir_all(parent)?;
         }
 
         let serialized_store = serde_json::to_string_pretty(self)?;
-        fs::write(&*STORE_ABSPATH, serialized_store)?;
+        fs::write(&*APP_STORE_ABSPATH, serialized_store)?;
 
         Ok(())
     }
 }
 
 pub fn get_active_spaceref() -> Option<SpaceReference> {
-    ZAKU_STORE.read().ok()?.active_spaceref.clone()
+    APP_STORE.read().ok()?.active_spaceref.clone()
 }
 
 pub fn set_active_spaceref(space_reference: SpaceReference) -> Result<()> {
-    let mut zaku_store = ZAKU_STORE
+    let mut app_store = APP_STORE
         .write()
         .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
-    zaku_store.active_spaceref = Some(space_reference);
-    zaku_store.persist()
+    app_store.active_spaceref = Some(space_reference);
+    app_store.persist()
 }
 
 pub fn get_spacerefs() -> Vec<SpaceReference> {
-    ZAKU_STORE
+    APP_STORE
         .read()
         .map(|s| s.spacerefs.clone())
         .unwrap_or_default()
 }
 
 pub fn set_spacerefs(spacerefs: Vec<SpaceReference>) -> Result<()> {
-    let mut zaku_store = ZAKU_STORE
+    let mut app_store = APP_STORE
         .write()
         .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
-    zaku_store.spacerefs = spacerefs;
-    zaku_store.persist()
+    app_store.spacerefs = spacerefs;
+    app_store.persist()
 }
 
 pub fn insert_spaceref_if_missing(space_reference: SpaceReference) -> Result<()> {
-    let mut zaku_store = ZAKU_STORE
+    let mut app_store = APP_STORE
         .write()
         .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
 
-    let spaceref_exists = zaku_store
+    let spaceref_exists = app_store
         .spacerefs
         .iter()
         .any(|r| r.path == space_reference.path);
 
     if !spaceref_exists {
-        zaku_store.spacerefs.push(space_reference);
-        zaku_store.persist()?;
+        app_store.spacerefs.push(space_reference);
+        app_store.persist()?;
     }
 
     Ok(())
 }
 
 pub fn remove_spaceref(space_reference: SpaceReference) -> Result<()> {
-    let mut zaku_store = ZAKU_STORE
+    let mut app_store = APP_STORE
         .write()
         .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
 
-    zaku_store
+    app_store
         .spacerefs
         .retain(|r| r.path != space_reference.path);
 
-    if let Some(active) = &zaku_store.active_spaceref {
+    if let Some(active) = &app_store.active_spaceref {
         if active.path == space_reference.path {
-            zaku_store.active_spaceref = None;
+            app_store.active_spaceref = None;
         }
     }
 
-    zaku_store.persist()
+    app_store.persist()
 }

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -89,7 +89,7 @@ pub fn insert_spaceref_if_missing(space_reference: SpaceReference) {
     }
 }
 
-pub fn delete_spaceref(space_reference: SpaceReference) {
+pub fn remove_spaceref(space_reference: SpaceReference) {
     let mut zaku_store = ZakuStore::acq_wlock();
 
     zaku_store

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -20,9 +20,9 @@ static ZAKU_STORE: Lazy<RwLock<ZakuStore>> = Lazy::new(|| {
         let content = fs::read_to_string(&*STORE_ABSPATH).expect("Failed to read from store");
         let store: ZakuStore = serde_json::from_str(&content).expect("Failed to deserialize data");
 
-        return RwLock::new(store);
+        RwLock::new(store)
     } else {
-        return RwLock::new(ZakuStore::default());
+        RwLock::new(ZakuStore::default())
     }
 });
 
@@ -51,7 +51,7 @@ impl ZakuStore {
 pub fn get_active_spaceref() -> Option<SpaceReference> {
     let zaku_store = ZakuStore::acq_rlock();
 
-    return zaku_store.active_spaceref.clone();
+    zaku_store.active_spaceref.clone()
 }
 
 pub fn set_active_spaceref(space_reference: SpaceReference) {
@@ -64,7 +64,7 @@ pub fn set_active_spaceref(space_reference: SpaceReference) {
 pub fn get_spacerefs() -> Vec<SpaceReference> {
     let zaku_store = ZakuStore::acq_rlock();
 
-    return zaku_store.spacerefs.clone();
+    zaku_store.spacerefs.clone()
 }
 
 pub fn set_spacerefs(spacerefs: Vec<SpaceReference>) {

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -1,9 +1,13 @@
 use once_cell::sync::Lazy;
 use std::fs::{self};
-use std::path::PathBuf;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
-use crate::{space::models::SpaceReference, store::models::ZakuStore};
+use crate::{
+    error::{Error, Result},
+    space::models::SpaceReference,
+    store::models::ZakuStore,
+};
 
 pub mod models;
 pub mod spaces;
@@ -15,92 +19,91 @@ pub static STORE_ABSPATH: Lazy<PathBuf> = Lazy::new(|| {
         .with_extension("json")
 });
 
-static ZAKU_STORE: Lazy<RwLock<ZakuStore>> = Lazy::new(|| {
-    if STORE_ABSPATH.exists() {
-        let content = fs::read_to_string(&*STORE_ABSPATH).expect("Failed to read from store");
-        let store: ZakuStore = serde_json::from_str(&content).expect("Failed to deserialize data");
-
-        RwLock::new(store)
-    } else {
-        RwLock::new(ZakuStore::default())
-    }
+static ZAKU_STORE: Lazy<RwLock<ZakuStore>> = Lazy::new(|| match ZakuStore::load(&STORE_ABSPATH) {
+    Ok(store) => RwLock::new(store),
+    Err(_) => RwLock::new(ZakuStore::default()),
 });
 
 impl ZakuStore {
-    fn acq_rlock() -> RwLockReadGuard<'static, Self> {
-        ZAKU_STORE.read().expect("Failed to acquire read lock")
+    fn load(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .map_err(|_| Error::FileReadError("Failed to read store file".into()))?;
+        let store = serde_json::from_str(&content)?;
+
+        Ok(store)
     }
 
-    fn acq_wlock() -> RwLockWriteGuard<'static, Self> {
-        ZAKU_STORE.write().expect("Failed to acquire write lock")
-    }
-
-    fn persist(&self) {
-        let serialized_store =
-            serde_json::to_string_pretty(self).expect("Failed to serialize store data");
-
+    fn persist(&self) -> Result<()> {
         if let Some(parent) = STORE_ABSPATH.parent() {
-            fs::create_dir_all(parent).expect("Failed to create parent directories");
+            fs::create_dir_all(parent)?;
         }
 
-        fs::write(&*STORE_ABSPATH, serialized_store)
-            .expect("Failed to write serialized store to disk");
+        let serialized_store = serde_json::to_string_pretty(self)?;
+        fs::write(&*STORE_ABSPATH, serialized_store)?;
+
+        Ok(())
     }
 }
 
 pub fn get_active_spaceref() -> Option<SpaceReference> {
-    let zaku_store = ZakuStore::acq_rlock();
-
-    zaku_store.active_spaceref.clone()
+    ZAKU_STORE.read().ok()?.active_spaceref.clone()
 }
 
-pub fn set_active_spaceref(space_reference: SpaceReference) {
-    let mut zaku_store = ZakuStore::acq_wlock();
+pub fn set_active_spaceref(space_reference: SpaceReference) -> Result<()> {
+    let mut zaku_store = ZAKU_STORE
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
     zaku_store.active_spaceref = Some(space_reference);
-
-    ZakuStore::persist(&zaku_store);
+    zaku_store.persist()
 }
 
 pub fn get_spacerefs() -> Vec<SpaceReference> {
-    let zaku_store = ZakuStore::acq_rlock();
-
-    zaku_store.spacerefs.clone()
+    ZAKU_STORE
+        .read()
+        .map(|s| s.spacerefs.clone())
+        .unwrap_or_default()
 }
 
-pub fn set_spacerefs(spacerefs: Vec<SpaceReference>) {
-    let mut zaku_store = ZakuStore::acq_wlock();
+pub fn set_spacerefs(spacerefs: Vec<SpaceReference>) -> Result<()> {
+    let mut zaku_store = ZAKU_STORE
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
     zaku_store.spacerefs = spacerefs;
-
-    ZakuStore::persist(&zaku_store);
+    zaku_store.persist()
 }
 
-pub fn insert_spaceref_if_missing(space_reference: SpaceReference) {
-    let mut zaku_store = ZakuStore::acq_wlock();
+pub fn insert_spaceref_if_missing(space_reference: SpaceReference) -> Result<()> {
+    let mut zaku_store = ZAKU_STORE
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
 
-    let reference_exists = zaku_store
+    let spaceref_exists = zaku_store
         .spacerefs
         .iter()
-        .any(|reference| reference.path == space_reference.path);
+        .any(|r| r.path == space_reference.path);
 
-    if !reference_exists {
+    if !spaceref_exists {
         zaku_store.spacerefs.push(space_reference);
-
-        ZakuStore::persist(&zaku_store);
+        zaku_store.persist()?;
     }
+
+    Ok(())
 }
 
-pub fn remove_spaceref(space_reference: SpaceReference) {
-    let mut zaku_store = ZakuStore::acq_wlock();
+pub fn remove_spaceref(space_reference: SpaceReference) -> Result<()> {
+    let mut zaku_store = ZAKU_STORE
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
 
     zaku_store
         .spacerefs
-        .retain(|reference| reference.path != space_reference.path);
+        .retain(|r| r.path != space_reference.path);
 
-    if let Some(active_space) = &zaku_store.active_spaceref {
-        if active_space.path == space_reference.path {
+    if let Some(active) = &zaku_store.active_spaceref {
+        if active.path == space_reference.path {
             zaku_store.active_spaceref = None;
         }
     }
 
-    ZakuStore::persist(&zaku_store);
+    zaku_store.persist()
 }

--- a/src-tauri/src/store/models.rs
+++ b/src-tauri/src/store/models.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
@@ -39,12 +37,6 @@ impl ReqBuf {
 
         Self { meta, config }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
-pub struct SpaceBuf {
-    pub abspath: String,
-    pub requests: HashMap<String, ReqBuf>,
 }
 
 pub struct SpaceCookies;

--- a/src-tauri/src/store/models.rs
+++ b/src-tauri/src/store/models.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ZakuStore {
+pub struct AppStore {
     pub active_spaceref: Option<SpaceReference>,
     pub spacerefs: Vec<SpaceReference>,
 }

--- a/src-tauri/src/store/spaces/buffer.rs
+++ b/src-tauri/src/store/spaces/buffer.rs
@@ -1,99 +1,104 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
 use std::collections::HashMap;
 use std::fs::{self};
-use std::io::Error;
-use std::path::{Path, PathBuf};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::path::Path;
+use std::sync::RwLock;
 
 use crate::{
+    error::{Error, Result},
     request,
     request::models::{HttpReq, ReqToml},
-    store::models::{ReqBuf, SpaceBuf},
+    store::models::ReqBuf,
     utils::{hashed_filename, ZAKU_DATA_DIR},
 };
 
 const SETTINGS_FILENAME: &str = "buffer.json";
 
+#[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
+pub struct SpaceBuf {
+    pub abspath: String,
+    pub requests: HashMap<String, ReqBuf>,
+}
+
 impl SpaceBuf {
-    pub fn load(space_abspath: &Path) -> RwLock<Self> {
+    pub fn load(space_abspath: &Path) -> Result<RwLock<Self>> {
         let spacebuf_file = ZAKU_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hashed_filename(&space_abspath.to_string_lossy()))
             .join(SETTINGS_FILENAME);
 
         if spacebuf_file.exists() {
-            let content =
-                fs::read_to_string(&spacebuf_file).expect("Failed to read from space buffer");
-            let space_buffer: Result<SpaceBuf, _> = serde_json::from_str(&content);
+            let content = fs::read_to_string(&spacebuf_file)
+                .map_err(|_| Error::FileReadError("Failed to read from space buffer".into()))?;
 
-            return RwLock::new(space_buffer.unwrap_or_else(|_| SpaceBuf {
-                abspath: space_abspath.to_string_lossy().to_string(),
-                requests: HashMap::new(),
-            }));
-        } else {
-            return RwLock::new(SpaceBuf {
+            let space_buffer = serde_json::from_str(&content).unwrap_or_else(|_| SpaceBuf {
                 abspath: space_abspath.to_string_lossy().to_string(),
                 requests: HashMap::new(),
             });
+
+            Ok(RwLock::new(space_buffer))
+        } else {
+            Ok(RwLock::new(SpaceBuf {
+                abspath: space_abspath.to_string_lossy().to_string(),
+                requests: HashMap::new(),
+            }))
         }
     }
 
-    pub fn acq_rlock(space_buffer: &RwLock<Self>) -> RwLockReadGuard<Self> {
-        return space_buffer.read().expect("Failed to acquire read lock");
-    }
-
-    pub fn acq_wlock(space_buffer: &RwLock<Self>) -> RwLockWriteGuard<Self> {
-        return space_buffer.write().expect("Failed to acquire write lock");
-    }
-
-    pub fn persist(&self) {
+    pub fn persist(&self) -> Result<()> {
         let buf_filepath = ZAKU_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hashed_filename(&self.abspath))
             .join(SETTINGS_FILENAME);
 
         if let Some(parent) = buf_filepath.parent() {
-            fs::create_dir_all(parent).expect("Failed to create parent directories");
+            fs::create_dir_all(parent)?;
         }
 
-        let serialized_store =
-            serde_json::to_string_pretty(self).expect("Failed to serialize store data");
+        let serialized_store = serde_json::to_string_pretty(self)?;
+        fs::write(&buf_filepath, serialized_store)?;
 
-        fs::write(&buf_filepath, serialized_store)
-            .expect("Failed to write serialized store to disk");
+        Ok(())
     }
 }
 
-pub fn persist_req_to_spacebuf(space_abspath: &Path, parent_relpath: &Path, request: HttpReq) {
-    let space_buffer = SpaceBuf::load(space_abspath);
-    let mut spacebuf_wlock = SpaceBuf::acq_wlock(&space_buffer);
-    let req_relpath = PathBuf::from(parent_relpath)
+pub fn persist_req_to_spacebuf(
+    space_abspath: &Path,
+    parent_relpath: &Path,
+    request: HttpReq,
+) -> Result<()> {
+    let space_buffer = SpaceBuf::load(space_abspath)?;
+    let mut spacebuf_wlock = space_buffer
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
+
+    let req_relpath = parent_relpath
         .join(&request.meta.file_name)
         .to_string_lossy()
         .to_string();
     let req_buf = ReqBuf::from_req(&request);
 
     spacebuf_wlock.requests.insert(req_relpath, req_buf);
+    spacebuf_wlock.persist()?;
 
-    spacebuf_wlock.persist();
+    Ok(())
 }
 
-pub fn write_reqbuf_to_reqtoml(space_abspath: &Path, req_relpath: &Path) -> Result<(), Error> {
-    let space_buf = SpaceBuf::load(space_abspath);
-    let mut spacebuf_wlock = SpaceBuf::acq_wlock(&space_buf);
+pub fn write_reqbuf_to_reqtoml(space_abspath: &Path, req_relpath: &Path) -> Result<()> {
+    let space_buffer = SpaceBuf::load(space_abspath)?;
+    let mut spacebuf_wlock = space_buffer
+        .write()
+        .map_err(|_| Error::LockError("Failed to acquire write lock".into()))?;
 
-    let req_buf = spacebuf_wlock
-        .requests
-        .get(&req_relpath.to_string_lossy().to_string());
-
-    if let Some(req_buf) = req_buf {
+    let relpath_str = req_relpath.to_string_lossy().to_string();
+    if let Some(req_buf) = spacebuf_wlock.requests.get(&relpath_str) {
         let req_toml = ReqToml::from_reqbuf(req_buf);
-        request::persist_reqtoml(&space_abspath.join(req_relpath), &req_toml).unwrap();
+        request::persist_reqtoml(&space_abspath.join(req_relpath), &req_toml)?;
     }
 
-    spacebuf_wlock
-        .requests
-        .remove(&req_relpath.to_string_lossy().to_string());
-    spacebuf_wlock.persist();
+    spacebuf_wlock.requests.remove(&relpath_str);
+    spacebuf_wlock.persist()?;
 
     Ok(())
 }

--- a/src-tauri/src/store/spaces/buffer.rs
+++ b/src-tauri/src/store/spaces/buffer.rs
@@ -10,7 +10,7 @@ use crate::{
     request,
     request::models::{HttpReq, ReqToml},
     store::models::ReqBuf,
-    utils::{hashed_filename, ZAKU_DATA_DIR},
+    utils::{hashed_filename, APP_DATA_DIR},
 };
 
 const SETTINGS_FILENAME: &str = "buffer.json";
@@ -23,7 +23,7 @@ pub struct SpaceBuf {
 
 impl SpaceBuf {
     pub fn load(space_abspath: &Path) -> Result<RwLock<Self>> {
-        let spacebuf_file = ZAKU_DATA_DIR
+        let spacebuf_file = APP_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hashed_filename(&space_abspath.to_string_lossy()))
             .join(SETTINGS_FILENAME);
@@ -47,7 +47,7 @@ impl SpaceBuf {
     }
 
     pub fn persist(&self) -> Result<()> {
-        let buf_filepath = ZAKU_DATA_DIR
+        let buf_filepath = APP_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hashed_filename(&self.abspath))
             .join(SETTINGS_FILENAME);

--- a/src-tauri/src/store/spaces/buffer.rs
+++ b/src-tauri/src/store/spaces/buffer.rs
@@ -95,5 +95,5 @@ pub fn write_reqbuf_to_reqtoml(space_abspath: &Path, req_relpath: &Path) -> Resu
         .remove(&req_relpath.to_string_lossy().to_string());
     spacebuf_wlock.persist();
 
-    return Ok(());
+    Ok(())
 }

--- a/src-tauri/src/store/spaces/cookie.rs
+++ b/src-tauri/src/store/spaces/cookie.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Error, Result},
     space::models::RemoveCookieDto,
     store::models::SpaceCookies,
-    utils::{hashed_filename, ZAKU_DATA_DIR},
+    utils::{hashed_filename, APP_DATA_DIR},
 };
 
 type CookiesCache = Mutex<HashMap<String, Arc<CookieStoreMutex>>>;
@@ -31,7 +31,7 @@ impl SpaceCookies {
             return Ok(Arc::clone(space_cookies));
         }
 
-        let cookie_file = ZAKU_DATA_DIR
+        let cookie_file = APP_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hsh_space_abspath)
             .join("cookies.json");
@@ -57,7 +57,7 @@ impl SpaceCookies {
             .map_err(|_| Error::LockError("Failed to lock cookie cache".into()))?;
 
         if let Some(space_cookies) = cache.get(space_abspath) {
-            let cookie_file = ZAKU_DATA_DIR
+            let cookie_file = APP_DATA_DIR
                 .join(super::SPACES_STORE_DIR)
                 .join(&hsh_space_abspath)
                 .join("cookies.json");

--- a/src-tauri/src/store/spaces/cookie.rs
+++ b/src-tauri/src/store/spaces/cookie.rs
@@ -1,7 +1,4 @@
-use cookie_store::{
-    serde::json::{load as read_cookie_json, save as write_cookie_json},
-    Cookie,
-};
+use cookie_store::{serde::json as cookie_json, Cookie};
 use once_cell::sync::Lazy;
 use reqwest_cookie_store::{CookieStore, CookieStoreMutex};
 use std::{
@@ -12,6 +9,7 @@ use std::{
 };
 
 use crate::{
+    error::{Error, Result},
     space::models::RemoveCookieDto,
     store::models::SpaceCookies,
     utils::{hashed_filename, ZAKU_DATA_DIR},
@@ -22,23 +20,25 @@ type CookiesCache = Mutex<HashMap<String, Arc<CookieStoreMutex>>>;
 static COOKIES_CACHE: Lazy<CookiesCache> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 impl SpaceCookies {
-    pub fn load(space_abspath: &str) -> Arc<CookieStoreMutex> {
+    pub fn load(space_abspath: &str) -> Result<Arc<CookieStoreMutex>> {
         let hsh_space_abspath = hashed_filename(space_abspath);
 
-        let mut cache = COOKIES_CACHE.lock().expect("Failed to lock cookie cache");
+        let mut cache = COOKIES_CACHE
+            .lock()
+            .map_err(|_| Error::FileReadError("Failed to lock cookie cache".into()))?;
+
         if let Some(space_cookies) = cache.get(space_abspath) {
-            return Arc::clone(space_cookies);
+            return Ok(Arc::clone(space_cookies));
         }
 
         let cookie_file = ZAKU_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(&hsh_space_abspath)
             .join("cookies.json");
+
         let space_cookiestore = if cookie_file.exists() {
-            let file = fs::File::open(&cookie_file)
-                .map(BufReader::new)
-                .expect("Failed to open cookie file");
-            read_cookie_json(file).unwrap_or_else(|_| CookieStore::default())
+            let file = fs::File::open(&cookie_file).map(BufReader::new)?;
+            cookie_json::load(file).unwrap_or_else(|_| CookieStore::default())
         } else {
             CookieStore::default()
         };
@@ -46,13 +46,16 @@ impl SpaceCookies {
         let space_cookies = Arc::new(CookieStoreMutex::new(space_cookiestore));
         cache.insert(space_abspath.to_string(), Arc::clone(&space_cookies));
 
-        return space_cookies;
+        Ok(space_cookies)
     }
 
-    pub fn persist(space_abspath: &str) {
+    pub fn persist(space_abspath: &str) -> Result<()> {
         let hsh_space_abspath = hashed_filename(space_abspath);
 
-        let cache = COOKIES_CACHE.lock().expect("Failed to lock cookie cache");
+        let cache = COOKIES_CACHE
+            .lock()
+            .map_err(|_| Error::LockError("Failed to lock cookie cache".into()))?;
+
         if let Some(space_cookies) = cache.get(space_abspath) {
             let cookie_file = ZAKU_DATA_DIR
                 .join(super::SPACES_STORE_DIR)
@@ -60,37 +63,51 @@ impl SpaceCookies {
                 .join("cookies.json");
 
             if let Some(parent) = cookie_file.parent() {
-                fs::create_dir_all(parent).expect("Failed to create cookie directory");
+                fs::create_dir_all(parent)?;
             }
 
-            let mut writer = fs::File::create(&cookie_file)
-                .map(BufWriter::new)
-                .expect("Failed to create cookie file");
+            let mut writer = fs::File::create(&cookie_file).map(BufWriter::new)?;
+            let locked = space_cookies
+                .lock()
+                .map_err(|_| Error::LockError("Failed to lock cookie store".into()))?;
 
-            let locked = space_cookies.lock().unwrap();
-            write_cookie_json(&*locked, &mut writer).expect("Failed to persist cookie store");
+            cookie_json::save(&*locked, &mut writer)?;
         }
+
+        Ok(())
     }
 
-    pub fn clear(space_abspath: &str) {
-        let space_cookies = SpaceCookies::load(space_abspath);
+    pub fn clear(space_abspath: &str) -> Result<()> {
+        let space_cookies = SpaceCookies::load(space_abspath)?;
+
         {
-            let mut locked = space_cookies.lock().unwrap();
+            let mut locked = space_cookies
+                .lock()
+                .map_err(|_| Error::LockError("Failed to lock cookie store".into()))?;
             locked.clear();
         }
-        SpaceCookies::persist(space_abspath);
+
+        SpaceCookies::persist(space_abspath)?;
+
+        Ok(())
     }
 
-    pub fn remove(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> Option<Cookie<'static>> {
+    pub fn remove(
+        space_abspath: &str,
+        rm_cookie_dto: RemoveCookieDto,
+    ) -> Result<Option<Cookie<'static>>> {
         let RemoveCookieDto { domain, path, name } = rm_cookie_dto;
-        let space_cookies = SpaceCookies::load(space_abspath);
-        let removed = {
-            let mut locked = space_cookies.lock().unwrap();
+        let space_cookies = SpaceCookies::load(space_abspath)?;
 
+        let removed = {
+            let mut locked = space_cookies
+                .lock()
+                .map_err(|_| Error::LockError("Failed to lock cookie store".into()))?;
             locked.remove(&domain, &path, &name)
         };
-        SpaceCookies::persist(space_abspath);
 
-        return removed;
+        SpaceCookies::persist(space_abspath)?;
+
+        Ok(removed)
     }
 }

--- a/src-tauri/src/store/spaces/settings.rs
+++ b/src-tauri/src/store/spaces/settings.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::{
     error::Result,
     store::models::SpaceSettings,
-    utils::{hashed_filename, ZAKU_DATA_DIR},
+    utils::{hashed_filename, APP_DATA_DIR},
 };
 
 const SETTINGS_FILENAME: &str = "settings.json";
@@ -34,7 +34,7 @@ impl SpaceSettings {
     fn filepath(space_abspath: &str) -> PathBuf {
         let hsh = hashed_filename(space_abspath);
 
-        ZAKU_DATA_DIR
+        APP_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(hsh)
             .join(SETTINGS_FILENAME)

--- a/src-tauri/src/store/spaces/settings.rs
+++ b/src-tauri/src/store/spaces/settings.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::{
+    error::Result,
     store::models::SpaceSettings,
     utils::{hashed_filename, ZAKU_DATA_DIR},
 };
@@ -9,42 +10,23 @@ use crate::{
 const SETTINGS_FILENAME: &str = "settings.json";
 
 impl SpaceSettings {
-    pub fn load(space_abspath: &str) -> SpaceSettings {
+    pub fn load(space_abspath: &str) -> Result<Self> {
         let settings_path = Self::filepath(space_abspath);
-        let file_content = fs::read_to_string(&settings_path)
-            .map_err(|error| {
-                eprintln!("Failed to read settings file: {}", error);
-            })
-            .unwrap_or_default();
-        let settings = serde_json::from_str(&file_content)
-            .map_err(|error| {
-                eprintln!("Failed to parse settings file: {}", error);
-            })
-            .unwrap_or_default();
+        let file_content = fs::read_to_string(&settings_path).unwrap_or_default();
+        let settings = serde_json::from_str(&file_content).unwrap_or_default();
 
-        return settings;
+        Ok(settings)
     }
 
-    pub fn persist(space_abspath: &str, settings: &SpaceSettings) -> Result<(), std::io::Error> {
+    pub fn persist(space_abspath: &str, settings: &Self) -> Result<()> {
         let settings_path = Self::filepath(space_abspath);
+
         if let Some(parent_dir) = settings_path.parent() {
-            fs::create_dir_all(parent_dir).map_err(|error| {
-                eprintln!("Could not create settings directory: {}", error);
-                error
-            })?;
+            fs::create_dir_all(parent_dir)?;
         }
 
-        let jsonstr = serde_json::to_string_pretty(settings).map_err(|error| {
-            eprintln!("Could not serialize settings: {}", error);
-
-            return std::io::Error::new(std::io::ErrorKind::Other, error);
-        })?;
-
-        fs::write(&settings_path, jsonstr).map_err(|error| {
-            eprintln!("Could not write settings file: {}", error);
-
-            return error;
-        })?;
+        let jsonstr = serde_json::to_string_pretty(settings)?;
+        fs::write(&settings_path, jsonstr)?;
 
         Ok(())
     }
@@ -52,9 +34,9 @@ impl SpaceSettings {
     fn filepath(space_abspath: &str) -> PathBuf {
         let hsh = hashed_filename(space_abspath);
 
-        return ZAKU_DATA_DIR
+        ZAKU_DATA_DIR
             .join(super::SPACES_STORE_DIR)
             .join(hsh)
-            .join(SETTINGS_FILENAME);
+            .join(SETTINGS_FILENAME)
     }
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -51,16 +51,16 @@ pub fn to_indexmap(fields: &[(bool, String, String)]) -> Option<IndexMap<String,
 }
 
 pub fn join_str_paths(paths: Vec<&str>) -> String {
-    return paths
+    paths
         .into_iter()
         .filter(|path| !path.is_empty())
         .collect::<Vec<&str>>()
-        .join("/");
+        .join("/")
 }
 
 pub fn hashed_filename(abspath: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(abspath.as_bytes());
 
-    return format!("{:x}", hasher.finalize());
+    format!("{:x}", hasher.finalize())
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -14,7 +14,7 @@ pub fn toggle_devtools(app_handle: &AppHandle) {
     }
 }
 
-pub static ZAKU_DATA_DIR: Lazy<PathBuf> = Lazy::new(|| {
+pub static APP_DATA_DIR: Lazy<PathBuf> = Lazy::new(|| {
     dirs::data_dir()
         .expect("Unable to get data directory")
         .join("Zaku")

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -5,7 +5,7 @@
 export const commands = {
     async getSharedState(): Promise<Result<SharedState, CmdErr>> {
         try {
-            return { status: "ok", data: await TAURI_INVOKE("get_sharedstate") };
+            return { status: "ok", data: await TAURI_INVOKE("get_shared_state") };
         } catch (e) {
             if (e instanceof Error) throw e;
             else return { status: "error", error: e as any };
@@ -251,6 +251,7 @@ export type ReqUrl = {
     host?: string;
     path?: string;
 };
+export type SharedState = { active_space: Space | null; spacerefs: SpaceReference[] };
 export type Space = {
     abspath: string;
     meta: SpaceMeta;
@@ -272,7 +273,6 @@ export type SpaceMeta = { name: string };
 export type SpaceReference = { path: string; name: string };
 export type SpaceSettings = { theme: Theme; notifications: NotificationSettings };
 export type Theme = "System" | "Light" | "Dark";
-export type SharedState = { active_space: Space | null; spacerefs: SpaceReference[] };
 
 /** tauri-specta globals **/
 

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -203,8 +203,8 @@ export const commands = {
 
 export type AudioNotification = { on_req_finish: boolean };
 export type CmdErr =
-    | { Msg: { message: string } }
-    | { Http: { message: string; code: number | null } };
+    | { type: "Err"; message: string }
+    | { type: "Http"; message: string; code: number | null };
 export type Collection = { meta: CollectionMeta; requests: HttpReq[]; collections: Collection[] };
 export type CollectionMeta = {
     dir_name: string;

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -3,9 +3,9 @@
 /** user-defined commands **/
 
 export const commands = {
-    async getZakuState(): Promise<Result<ZakuState, CmdErr>> {
+    async getSharedState(): Promise<Result<SharedState, CmdErr>> {
         try {
-            return { status: "ok", data: await TAURI_INVOKE("get_zaku_state") };
+            return { status: "ok", data: await TAURI_INVOKE("get_sharedstate") };
         } catch (e) {
             if (e instanceof Error) throw e;
             else return { status: "error", error: e as any };
@@ -272,7 +272,7 @@ export type SpaceMeta = { name: string };
 export type SpaceReference = { path: string; name: string };
 export type SpaceSettings = { theme: Theme; notifications: NotificationSettings };
 export type Theme = "System" | "Light" | "Dark";
-export type ZakuState = { active_space: Space | null; spacerefs: SpaceReference[] };
+export type SharedState = { active_space: Space | null; spacerefs: SpaceReference[] };
 
 /** tauri-specta globals **/
 

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -3,7 +3,7 @@
 /** user-defined commands **/
 
 export const commands = {
-    async getZakuState(): Promise<Result<ZakuState, string>> {
+    async getZakuState(): Promise<Result<ZakuState, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("get_zaku_state") };
         } catch (e) {
@@ -11,7 +11,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async createSpace(createSpaceDto: CreateSpaceDto): Promise<Result<SpaceReference, ZakuError>> {
+    async createSpace(createSpaceDto: CreateSpaceDto): Promise<Result<SpaceReference, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("create_space", { createSpaceDto }) };
         } catch (e) {
@@ -19,7 +19,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async setActiveSpace(spaceReference: SpaceReference): Promise<Result<null, ZakuError>> {
+    async setActiveSpace(spaceReference: SpaceReference): Promise<Result<null, CmdErr>> {
         try {
             return {
                 status: "ok",
@@ -30,10 +30,10 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async deleteSpace(spaceReference: SpaceReference): Promise<null> {
-        return await TAURI_INVOKE("delete_space", { spaceReference });
+    async removeSpace(spaceReference: SpaceReference): Promise<null> {
+        return await TAURI_INVOKE("remove_space", { spaceReference });
     },
-    async getSpaceref(path: string): Promise<Result<SpaceReference, ZakuError>> {
+    async getSpaceref(path: string): Promise<Result<SpaceReference, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("get_spaceref", { path }) };
         } catch (e) {
@@ -46,7 +46,7 @@ export const commands = {
     },
     async getSpaceCookies(
         spaceAbspath: string,
-    ): Promise<Result<Partial<{ [key in string]: SpaceCookie[] }>, ZakuError>> {
+    ): Promise<Result<Partial<{ [key in string]: SpaceCookie[] }>, CmdErr>> {
         try {
             return {
                 status: "ok",
@@ -60,7 +60,7 @@ export const commands = {
     async saveSpaceSettings(
         spaceAbspath: string,
         settings: SpaceSettings,
-    ): Promise<Result<null, ZakuError>> {
+    ): Promise<Result<null, CmdErr>> {
         try {
             return {
                 status: "ok",
@@ -74,7 +74,7 @@ export const commands = {
     async showMainWindow(): Promise<void> {
         await TAURI_INVOKE("show_main_window");
     },
-    async openDirDialog(options: OpenDirDialogOpt | null): Promise<Result<string | null, string>> {
+    async openDirDialog(options: OpenDirDialogOpt | null): Promise<Result<string | null, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("open_dir_dialog", { options }) };
         } catch (e) {
@@ -82,7 +82,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async isNotifEnabled(): Promise<Result<boolean, ZakuError>> {
+    async isNotifEnabled(): Promise<Result<boolean, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("is_notif_enabled") };
         } catch (e) {
@@ -90,7 +90,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async requestNotifAccess(): Promise<Result<boolean, ZakuError>> {
+    async requestNotifAccess(): Promise<Result<boolean, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("request_notif_access") };
         } catch (e) {
@@ -98,7 +98,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async dispatchNotif(options: DispatchNotificationOptions): Promise<Result<null, ZakuError>> {
+    async dispatchNotif(options: DispatchNotificationOptions): Promise<Result<null, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("dispatch_notif", { options }) };
         } catch (e) {
@@ -108,7 +108,7 @@ export const commands = {
     },
     async createCollection(
         createCollectionDto: CreateCollectionDto,
-    ): Promise<Result<CreateNewCollection, ZakuError>> {
+    ): Promise<Result<CreateNewCollection, CmdErr>> {
         try {
             return {
                 status: "ok",
@@ -119,7 +119,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async createReq(createReqDto: CreateRequestDto): Promise<Result<CreateNewRequest, ZakuError>> {
+    async createReq(createReqDto: CreateRequestDto): Promise<Result<CreateNewRequest, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("create_req", { createReqDto }) };
         } catch (e) {
@@ -127,13 +127,36 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async persistToReqbuf(spaceAbspath: string, relpath: string, request: HttpReq): Promise<void> {
-        await TAURI_INVOKE("persist_to_reqbuf", { spaceAbspath, relpath, request });
+    async persistToReqbuf(
+        spaceAbspath: string,
+        relpath: string,
+        request: HttpReq,
+    ): Promise<Result<null, CmdErr>> {
+        try {
+            return {
+                status: "ok",
+                data: await TAURI_INVOKE("persist_to_reqbuf", { spaceAbspath, relpath, request }),
+            };
+        } catch (e) {
+            if (e instanceof Error) throw e;
+            else return { status: "error", error: e as any };
+        }
     },
-    async writeReqbufToReqtoml(spaceAbspath: string, reqRelpath: string): Promise<void> {
-        await TAURI_INVOKE("write_reqbuf_to_reqtoml", { spaceAbspath, reqRelpath });
+    async writeReqbufToReqtoml(
+        spaceAbspath: string,
+        reqRelpath: string,
+    ): Promise<Result<null, CmdErr>> {
+        try {
+            return {
+                status: "ok",
+                data: await TAURI_INVOKE("write_reqbuf_to_reqtoml", { spaceAbspath, reqRelpath }),
+            };
+        } catch (e) {
+            if (e instanceof Error) throw e;
+            else return { status: "error", error: e as any };
+        }
     },
-    async httpReq(req: HttpReq): Promise<Result<HttpRes, HttpErr>> {
+    async httpReq(req: HttpReq): Promise<Result<HttpRes, CmdHttpErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("http_req", { req }) };
         } catch (e) {
@@ -141,7 +164,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async moveTreeitem(moveTreeitemDto: MoveTreeItemDto): Promise<Result<null, ZakuError>> {
+    async moveTreeitem(moveTreeitemDto: MoveTreeItemDto): Promise<Result<null, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("move_treeitem", { moveTreeitemDto }) };
         } catch (e) {
@@ -158,6 +181,8 @@ export const commands = {
 /** user-defined types **/
 
 export type AudioNotification = { on_req_finish: boolean };
+export type CmdErr = string;
+export type CmdHttpErr = { message: string; code: number | null };
 export type Collection = { meta: CollectionMeta; requests: HttpReq[]; collections: Collection[] };
 export type CollectionMeta = {
     dir_name: string;
@@ -170,7 +195,6 @@ export type CreateNewRequest = { parent_relpath: string; relpath: string };
 export type CreateRequestDto = { parent_relpath: string; relpath: string };
 export type CreateSpaceDto = { name: string; location: string };
 export type DispatchNotificationOptions = { title: string; body: string };
-export type HttpErr = { message: string; code: number | null };
 export type HttpReq = {
     meta: ReqMeta;
     config: ReqCfg;
@@ -226,7 +250,6 @@ export type SpaceMeta = { name: string };
 export type SpaceReference = { path: string; name: string };
 export type SpaceSettings = { theme: Theme; notifications: NotificationSettings };
 export type Theme = "System" | "Light" | "Dark";
-export type ZakuError = { error: string; message: string };
 export type ZakuState = { active_space: Space | null; spacerefs: SpaceReference[] };
 
 /** tauri-specta globals **/

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -30,8 +30,13 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async removeSpace(spaceReference: SpaceReference): Promise<null> {
-        return await TAURI_INVOKE("remove_space", { spaceReference });
+    async removeSpace(spaceReference: SpaceReference): Promise<Result<null, CmdErr>> {
+        try {
+            return { status: "ok", data: await TAURI_INVOKE("remove_space", { spaceReference }) };
+        } catch (e) {
+            if (e instanceof Error) throw e;
+            else return { status: "error", error: e as any };
+        }
     },
     async getSpaceref(path: string): Promise<Result<SpaceReference, CmdErr>> {
         try {
@@ -41,8 +46,19 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async removeCookie(spaceAbspath: string, rmCookieDto: RemoveCookieDto): Promise<boolean> {
-        return await TAURI_INVOKE("remove_cookie", { spaceAbspath, rmCookieDto });
+    async removeCookie(
+        spaceAbspath: string,
+        rmCookieDto: RemoveCookieDto,
+    ): Promise<Result<boolean, CmdErr>> {
+        try {
+            return {
+                status: "ok",
+                data: await TAURI_INVOKE("remove_cookie", { spaceAbspath, rmCookieDto }),
+            };
+        } catch (e) {
+            if (e instanceof Error) throw e;
+            else return { status: "error", error: e as any };
+        }
     },
     async getSpaceCookies(
         spaceAbspath: string,
@@ -71,8 +87,13 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async showMainWindow(): Promise<void> {
-        await TAURI_INVOKE("show_main_window");
+    async showMainWindow(): Promise<Result<null, CmdErr>> {
+        try {
+            return { status: "ok", data: await TAURI_INVOKE("show_main_window") };
+        } catch (e) {
+            if (e instanceof Error) throw e;
+            else return { status: "error", error: e as any };
+        }
     },
     async openDirDialog(options: OpenDirDialogOpt | null): Promise<Result<string | null, CmdErr>> {
         try {
@@ -156,7 +177,7 @@ export const commands = {
             else return { status: "error", error: e as any };
         }
     },
-    async httpReq(req: HttpReq): Promise<Result<HttpRes, CmdHttpErr>> {
+    async httpReq(req: HttpReq): Promise<Result<HttpRes, CmdErr>> {
         try {
             return { status: "ok", data: await TAURI_INVOKE("http_req", { req }) };
         } catch (e) {
@@ -181,8 +202,9 @@ export const commands = {
 /** user-defined types **/
 
 export type AudioNotification = { on_req_finish: boolean };
-export type CmdErr = string;
-export type CmdHttpErr = { message: string; code: number | null };
+export type CmdErr =
+    | { Msg: { message: string } }
+    | { Http: { message: string; code: number | null } };
 export type Collection = { meta: CollectionMeta; requests: HttpReq[]; collections: Collection[] };
 export type CollectionMeta = {
     dir_name: string;

--- a/src/lib/components/sidebar/sidebar.svelte
+++ b/src/lib/components/sidebar/sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { zakuState, treeActionsState } from "$lib/state.svelte";
+    import { sharedState, treeActionsState } from "$lib/state.svelte";
     import { Button } from "$lib/components/primitives/button";
     import { CookieIcon, SettingsIcon, ChevronsLeftIcon, CompassIcon, XIcon } from "@lucide/svelte";
     import type { PaneAPI } from "paneforge";
@@ -46,7 +46,7 @@
     let { pane, isCollapsed = $bindable() }: Props = $props();
 
     let spaceSettingsStr: string = $state(
-        zakuState.activeSpace ? JSON.stringify(zakuState.activeSpace.settings) : String(),
+        sharedState.activeSpace ? JSON.stringify(sharedState.activeSpace.settings) : String(),
     );
 
     let shouldRenderCreateNewRequestInput = $derived(
@@ -122,8 +122,8 @@
     </div>
 {/snippet}
 
-{#if zakuState.activeSpace}
-    {@const spaceRef = zakuState.activeSpace}
+{#if sharedState.activeSpace}
+    {@const spaceRef = sharedState.activeSpace}
     <div class="flex size-full flex-col justify-between">
         <div class="flex w-full items-center justify-center border-b p-1.5 pt-0">
             <div class={cn("flex w-full items-center justify-between gap-1.5")}>

--- a/src/lib/components/space/create-dialog.svelte
+++ b/src/lib/components/space/create-dialog.svelte
@@ -11,7 +11,7 @@
     import { Label } from "$lib/components/primitives/label";
     import { Input } from "$lib/components/primitives/input";
     import { tick } from "svelte";
-    import { zakuState } from "$lib/state.svelte";
+    import { sharedState } from "$lib/state.svelte";
     import { commands } from "$lib/bindings";
 
     type Props = {
@@ -58,7 +58,7 @@
             return;
         }
 
-        await zakuState.setActiveSpace(spaceReference.data);
+        await sharedState.setActiveSpace(spaceReference.data);
         isOpen = false;
 
         await onCreate();

--- a/src/lib/components/space/switcher.svelte
+++ b/src/lib/components/space/switcher.svelte
@@ -60,7 +60,7 @@
                     );
                 }
 
-                await commands.deleteSpace(spaceRefCmdResult.data);
+                await commands.removeSpace(spaceRefCmdResult.data);
                 await zakuState.synchronize();
 
                 return;

--- a/src/lib/components/space/switcher.svelte
+++ b/src/lib/components/space/switcher.svelte
@@ -2,7 +2,7 @@
     import { goto } from "$app/navigation";
     import { ChevronDownIcon, CheckIcon, PyramidIcon } from "@lucide/svelte";
 
-    import { treeActionsState, treeItemsState, zakuState } from "$lib/state.svelte";
+    import { treeActionsState, treeItemsState, sharedState } from "$lib/state.svelte";
     import { buttonVariants } from "$lib/components/primitives/button";
     import {
         DropdownMenu,
@@ -39,7 +39,7 @@
                 throw new Error(`Cannot get space reference for ${cmdResult.data}`);
             }
 
-            await zakuState.setActiveSpace(spaceRefCmdResult.data);
+            await sharedState.setActiveSpace(spaceRefCmdResult.data);
             await goto("/space");
         } catch (err) {
             console.error(err);
@@ -51,17 +51,19 @@
     }
 
     async function handleDeleteSpace() {
-        if (zakuState.activeSpace) {
+        if (sharedState.activeSpace) {
             try {
-                const spaceRefCmdResult = await commands.getSpaceref(zakuState.activeSpace.abspath);
+                const spaceRefCmdResult = await commands.getSpaceref(
+                    sharedState.activeSpace.abspath,
+                );
                 if (spaceRefCmdResult.status === "error") {
                     throw new Error(
-                        `Cannot get space reference for ${zakuState.activeSpace.abspath}`,
+                        `Cannot get space reference for ${sharedState.activeSpace.abspath}`,
                     );
                 }
 
                 await commands.removeSpace(spaceRefCmdResult.data);
-                await zakuState.synchronize();
+                await sharedState.synchronize();
 
                 return;
             } catch (err) {
@@ -71,7 +73,7 @@
     }
 </script>
 
-{#if zakuState.activeSpace}
+{#if sharedState.activeSpace}
     <DropdownMenu>
         <DropdownMenuTrigger
             class={cn(
@@ -86,7 +88,7 @@
             <PyramidIcon size={14} class="max-h-[14px] max-w-[14px]" />
             {#if !isSidebarCollapsed}
                 <div class="flex grow items-center justify-between overflow-hidden">
-                    <span class="truncate pr-0.5">{zakuState.activeSpace.meta.name}</span>
+                    <span class="truncate pr-0.5">{sharedState.activeSpace.meta.name}</span>
                     <ChevronDownIcon size={14} class="max-h-[14px] max-w-[14px]" />
                 </div>
             {/if}
@@ -101,11 +103,11 @@
                     <p>Switch Space</p>
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent class="w-[185px]" sideOffset={4}>
-                    {#each zakuState.spaceRefs as spaceRef (spaceRef.path)}
+                    {#each sharedState.spaceRefs as spaceRef (spaceRef.path)}
                         <DropdownMenuItem
                             class="text-small flex h-7 justify-between rounded-md px-2"
                             onclick={async () => {
-                                await zakuState.setActiveSpace(spaceRef);
+                                await sharedState.setActiveSpace(spaceRef);
                                 treeActionsState.reset();
                                 treeItemsState.reset();
                             }}
@@ -113,7 +115,7 @@
                             <div class="flex items-center overflow-hidden">
                                 <span class="truncate">{spaceRef.name}</span>
                             </div>
-                            {#if spaceRef.path === zakuState.activeSpace.abspath}
+                            {#if spaceRef.path === sharedState.activeSpace.abspath}
                                 <CheckIcon size={14} class="max-h-[14px] max-w-[14px]" />
                             {/if}
                         </DropdownMenuItem>

--- a/src/lib/components/tree-item/tree-item-create.svelte
+++ b/src/lib/components/tree-item/tree-item-create.svelte
@@ -4,7 +4,7 @@
     import type { UnlistenFn } from "@tauri-apps/api/event";
 
     import { TreeItemType } from "$lib/models";
-    import { zakuState, treeActionsState, treeItemsState } from "$lib/state.svelte";
+    import { sharedState, treeActionsState, treeItemsState } from "$lib/state.svelte";
     import { cn, getMethodColorClass } from "$lib/utils/style";
     import { CollectionIcon } from "$lib/components/icons";
     import { commands } from "$lib/bindings";
@@ -51,7 +51,7 @@
             }
 
             inputName = "";
-            await zakuState.synchronize();
+            await sharedState.synchronize();
 
             treeItemsState.focussedItem = {
                 type: TreeItemType.Collection,
@@ -78,7 +78,7 @@
             }
 
             inputName = "";
-            await zakuState.synchronize();
+            await sharedState.synchronize();
 
             treeItemsState.focussedItem = {
                 type: TreeItemType.Request,

--- a/src/lib/components/tree-item/utils.svelte.ts
+++ b/src/lib/components/tree-item/utils.svelte.ts
@@ -2,7 +2,7 @@ import { mount, unmount } from "svelte";
 import { toast } from "svelte-sonner";
 
 import { TreeItemPreview } from "$lib/components/tree-item";
-import { zakuState, treeActionsState, treeItemsState } from "$lib/state.svelte";
+import { sharedState, treeActionsState, treeItemsState } from "$lib/state.svelte";
 import { TreeItemType } from "$lib/models";
 import type { DragOverDto, DragPayload, RemoveTreeItemDto, TreeItem } from "$lib/models";
 import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
@@ -106,7 +106,7 @@ export async function handleDrop(event: DragEvent) {
     event.preventDefault();
     event.stopImmediatePropagation();
 
-    if (zakuState.activeSpace === null) {
+    if (sharedState.activeSpace === null) {
         console.warn("Active space not found");
         return;
     }
@@ -119,7 +119,7 @@ export async function handleDrop(event: DragEvent) {
         return;
     }
 
-    const mutRootCollection = zakuState.activeSpace.root;
+    const mutRootCollection = sharedState.activeSpace.root;
     const addTreeItemToCollectionResult = addTreeItemToCollection({
         parentRelativePath: treeActionsState.dragPayload.parentRelativePath,
         treeItem: treeActionsState.dragPayload.treeItem,

--- a/src/lib/components/tree-item/utils.svelte.ts
+++ b/src/lib/components/tree-item/utils.svelte.ts
@@ -6,7 +6,7 @@ import { sharedState, treeActionsState, treeItemsState } from "$lib/state.svelte
 import { TreeItemType } from "$lib/models";
 import type { DragOverDto, DragPayload, RemoveTreeItemDto, TreeItem } from "$lib/models";
 import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
-import { Err, Ok } from "$lib/utils";
+import { err, ok } from "$lib/utils";
 import { commands } from "$lib/bindings";
 import type { Result, MoveTreeItemDto, Collection } from "$lib/bindings";
 
@@ -222,7 +222,7 @@ export function addTreeItemToCollection({
 }: AddTreeItemToCollectionParams): Result<void, void> {
     if (targetPath === parentRelativePath) {
         console.warn(`Abort dropping to the same parent \`${parentRelativePath}\``);
-        return Err();
+        return err();
     }
 
     let current: Collection = mutRootCollection;
@@ -234,7 +234,7 @@ export function addTreeItemToCollection({
         );
         if (!nextCollection) {
             console.warn(`Target collection \`${segment}\` not found in \`${traversedPath}\``);
-            return Err();
+            return err();
         }
 
         current = nextCollection;
@@ -254,12 +254,12 @@ export function addTreeItemToCollection({
             console.warn(
                 `Abort moving collection to itself or it's own child collection \`${targetPath}\``,
             );
-            return Err();
+            return err();
         }
     } else {
         if (parentRelativePath === traversedPath) {
             console.warn(`Abort moving request into the same collection \`${targetPath}\``);
-            return Err();
+            return err();
         }
     }
 
@@ -272,14 +272,14 @@ export function addTreeItemToCollection({
                 `Collection with directory name ${treeItem.meta.dir_name} already exists in the ${current.meta.dir_name} collection`,
             );
 
-            return Err();
+            return err();
         }
         current.collections.push(treeItem);
         current.collections.sort((a, b) =>
             a.meta.dir_name.toLocaleLowerCase().localeCompare(b.meta.dir_name),
         );
 
-        return Ok();
+        return ok();
     } else {
         const reqFileNameAlreadyExists = current.requests.some(
             request => request.meta.file_name === treeItem.meta.file_name,
@@ -289,12 +289,12 @@ export function addTreeItemToCollection({
                 `Request with file name ${treeItem.meta.file_name} already exists in the ${current.meta.dir_name} collection`,
             );
 
-            return Err();
+            return err();
         }
         current.requests.push(treeItem);
         current.requests.sort((a, b) => a.meta.file_name.localeCompare(b.meta.file_name));
 
-        return Ok();
+        return ok();
     }
 }
 
@@ -319,7 +319,7 @@ export function removeTreeItemFromCollection({
         if (!nextCollection) {
             console.warn(`Collection not found for segment: ${segment}`);
 
-            return Err();
+            return err();
         }
 
         current = nextCollection;
@@ -330,12 +330,12 @@ export function removeTreeItemFromCollection({
             collection => collection.meta.dir_name !== removeTreeItemDto.dir_name,
         );
 
-        return Ok();
+        return ok();
     } else {
         current.requests = current.requests.filter(
             request => request.meta.file_name !== removeTreeItemDto.file_name,
         );
 
-        return Ok();
+        return ok();
     }
 }

--- a/src/lib/components/tree-item/utils.svelte.ts
+++ b/src/lib/components/tree-item/utils.svelte.ts
@@ -6,9 +6,9 @@ import { sharedState, treeActionsState, treeItemsState } from "$lib/state.svelte
 import { TreeItemType } from "$lib/models";
 import type { DragOverDto, DragPayload, RemoveTreeItemDto, TreeItem } from "$lib/models";
 import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
-import { commands, type Collection, type MoveTreeItemDto } from "$lib/bindings";
 import { Err, Ok } from "$lib/utils";
-import type { Result } from "$lib/utils";
+import { commands } from "$lib/bindings";
+import type { Result, MoveTreeItemDto, Collection } from "$lib/bindings";
 
 export function isCollection(treeItem: TreeItem): treeItem is Collection {
     return Object.hasOwn(treeItem.meta, "dir_name");
@@ -126,7 +126,7 @@ export async function handleDrop(event: DragEvent) {
         targetPath: treeActionsState.dropTargetPath,
         mutRootCollection,
     });
-    if (!addTreeItemToCollectionResult.ok) {
+    if (addTreeItemToCollectionResult.status === "error") {
         console.error("Cannot add tree item to the collection");
         return;
     }
@@ -145,7 +145,7 @@ export async function handleDrop(event: DragEvent) {
         removeTreeItemDto,
         mutRootCollection,
     });
-    if (!removeTreeItemFromCollectionResult.ok) {
+    if (removeTreeItemFromCollectionResult.status === "error") {
         console.error("Unable to remove tree item from the collection");
         return;
     }
@@ -219,7 +219,7 @@ export function addTreeItemToCollection({
     treeItem,
     targetPath,
     mutRootCollection,
-}: AddTreeItemToCollectionParams): Result<void> {
+}: AddTreeItemToCollectionParams): Result<void, void> {
     if (targetPath === parentRelativePath) {
         console.warn(`Abort dropping to the same parent \`${parentRelativePath}\``);
         return Err();
@@ -308,7 +308,7 @@ export function removeTreeItemFromCollection({
     parentRelativePath,
     removeTreeItemDto,
     mutRootCollection,
-}: RemoveTreeItemFromCollectionParams): Result<void> {
+}: RemoveTreeItemFromCollectionParams): Result<void, void> {
     const segments = pathSegments(parentRelativePath);
     let current: Collection = mutRootCollection;
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -2,36 +2,12 @@ import { tick } from "svelte";
 import { toast } from "svelte-sonner";
 
 import { version } from "$app/environment";
-import { RELATIVE_SPACE_ROOT, REQUEST_BODY_TYPES } from "$lib/utils/constants";
-import type { ValueOf } from "$lib/utils";
+import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
 import { TreeItemType } from "$lib/models";
 import type { ActiveRequest, DragPayload, FocussedTreeItem } from "$lib/models";
 import { commands } from "$lib/bindings";
 import type { SpaceReference, Space, HttpReq } from "$lib/bindings";
 import { joinPaths } from "./components/tree-item/utils.svelte";
-
-export type ReqCfg = ZakuReqCfg;
-
-export type MaybeKey<T extends string = string> = T | `_${T}`;
-
-export type SerializedValue = string | number | boolean | null;
-
-export type ZakuReqCfg = {
-    name: string;
-    method: string;
-    headers?: Record<MaybeKey, SerializedValue>;
-    params?: Record<MaybeKey, SerializedValue>;
-    body: {
-        active: ValueOf<typeof REQUEST_BODY_TYPES>;
-        "application/json": Record<string, SerializedValue>;
-        "application/xml": string;
-        "application/x-www-form-urlencoded": Record<string, SerializedValue>;
-        // "application/octet-stream": ?,
-        //  "multipart/form-data": ?,
-        "text/html": string;
-        "text/plain": string;
-    };
-};
 
 class SharedState {
     public activeSpace: Space | null = $state(null);

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -33,21 +33,21 @@ export type ZakuReqCfg = {
     };
 };
 
-class ZakuState {
+class SharedState {
     public activeSpace: Space | null = $state(null);
     public spaceRefs: SpaceReference[] = $state([]);
 
     public async synchronize() {
-        const getZakuStateResult = await commands.getZakuState();
+        const getSharedStateResult = await commands.getSharedState();
 
-        if (getZakuStateResult.status === "ok") {
-            this.activeSpace = getZakuStateResult.data.active_space;
-            this.spaceRefs = getZakuStateResult.data.spacerefs;
+        if (getSharedStateResult.status === "ok") {
+            this.activeSpace = getSharedStateResult.data.active_space;
+            this.spaceRefs = getSharedStateResult.data.spacerefs;
 
             treeActionsState.reset();
             await tick();
         } else {
-            console.error(getZakuStateResult.error);
+            console.error(getSharedStateResult.error);
             toast("Something went wrong while synchronizing state");
         }
     }
@@ -66,7 +66,7 @@ class ZakuState {
     }
 }
 
-export const zakuState = new ZakuState();
+export const sharedState = new SharedState();
 
 class TreeActionsState {
     public dragPayload: DragPayload | null = $state(null);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2,10 +2,10 @@ import type { Result } from "$lib/bindings";
 
 export type ValueOf<T> = T[keyof T];
 
-export function Ok<T = void>(value?: T): Result<T, never> {
+export function ok<T = void>(value?: T): Result<T, never> {
     return { status: "ok", data: value as T };
 }
 
-export function Err<E = void>(err?: E): Result<never, E> {
+export function err<E = void>(err?: E): Result<never, E> {
     return { status: "error", error: err as E };
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,44 +1,11 @@
+import type { Result } from "$lib/bindings";
+
 export type ValueOf<T> = T[keyof T];
 
-export type Ok<T> = {
-    ok: true;
-    value: T;
-};
-
-export function Ok<T = void>(value?: T): Ok<T> {
-    return { ok: true, value: value as T };
+export function Ok<T = void>(value?: T): Result<T, never> {
+    return { status: "ok", data: value as T };
 }
 
-export type Err<E> = {
-    ok: false;
-    err: E;
-};
-
-export function Err<E = void>(err?: E): Err<E> {
-    return { ok: false, err: err as E };
-}
-
-export type Result<T, E = void> = Ok<T> | Err<E>;
-
-export function isObject(value: unknown): value is object {
-    return typeof value === "object" && value !== null;
-}
-
-export function safeRun<TReturn, E = unknown>(result: TReturn): Result<TReturn, E> {
-    try {
-        return Ok(result);
-    } catch (err) {
-        return Err(err as E);
-    }
-}
-
-export async function safeRunAsync<TReturn, E = unknown>(
-    promise: Promise<TReturn>,
-): Promise<Result<TReturn, E>> {
-    try {
-        const result = await promise;
-        return Ok(result);
-    } catch (err) {
-        return Err(err as E);
-    }
+export function Err<E = void>(err?: E): Result<never, E> {
+    return { status: "error", error: err as E };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
     import "../app.css";
     import { Toaster } from "$lib/components/primitives/sonner";
     import { TitleBar } from "$lib/components/title-bar";
-    import { zakuState } from "$lib/state.svelte";
+    import { sharedState } from "$lib/state.svelte";
     import { commands } from "$lib/bindings";
 
     let { children }: { children: Snippet } = $props();
@@ -22,9 +22,9 @@
         if (!dev) {
             document.addEventListener("contextmenu", disableContextMenu);
         }
-        await zakuState.synchronize();
+        await sharedState.synchronize();
 
-        if (zakuState.activeSpace !== null) {
+        if (sharedState.activeSpace !== null) {
             await goto("/space");
         } else if (page.url.pathname !== "/") {
             await goto("/");
@@ -34,7 +34,7 @@
     });
 
     $effect(() => {
-        if (zakuState.activeSpace === null) {
+        if (sharedState.activeSpace === null) {
             goto("/");
         }
     });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Button } from "$lib/components/primitives/button";
     import { goto } from "$app/navigation";
-    import { zakuState } from "$lib/state.svelte";
+    import { sharedState } from "$lib/state.svelte";
     import { SpaceCreateDialog } from "$lib/components/space";
     import { commands } from "$lib/bindings";
 
@@ -22,7 +22,7 @@
                 throw new Error(`Cannot get space reference for ${cmdResult.data}`);
             }
 
-            await zakuState.setActiveSpace(spaceRefCmdResult.data);
+            await sharedState.setActiveSpace(spaceRefCmdResult.data);
             await goto("/space");
         } catch (err) {
             console.error(err);

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -13,7 +13,7 @@
     import { ConfigurationPane } from "$lib/components/configuration-pane";
     import { ResponsePane } from "$lib/components/response-pane";
     import { cn } from "$lib/utils/style";
-    import { treeItemsState, debounced, zakuState, baseRequestHeaders } from "$lib/state.svelte";
+    import { treeItemsState, debounced, sharedState, baseRequestHeaders } from "$lib/state.svelte";
     import { joinPaths } from "$lib/components/tree-item/utils.svelte";
     import { REQUEST_BODY_TYPES } from "$lib/utils/constants";
     import { commands } from "$lib/bindings";
@@ -84,11 +84,11 @@
 
         const httpRes = await commands.httpReq(req);
 
-        if (zakuState.activeSpace) {
-            const cookiesResult = await commands.getSpaceCookies(zakuState.activeSpace.abspath);
+        if (sharedState.activeSpace) {
+            const cookiesResult = await commands.getSpaceCookies(sharedState.activeSpace.abspath);
 
             if (cookiesResult.status === "ok") {
-                zakuState.activeSpace.cookies = cookiesResult.data;
+                sharedState.activeSpace.cookies = cookiesResult.data;
             }
         }
 
@@ -109,7 +109,7 @@
     }
 
     async function handleSave(event: KeyboardEvent) {
-        const activeSpaceRef = zakuState.activeSpace;
+        const activeSpaceRef = sharedState.activeSpace;
         const activeReqRef = treeItemsState.activeRequest;
         if (!activeSpaceRef || !activeReqRef) {
             return;
@@ -145,7 +145,7 @@
         // Important hack to keep the effect deeply reactive
         JSON.stringify(treeItemsState.activeRequest);
 
-        const activeSpaceRef = zakuState.activeSpace;
+        const activeSpaceRef = sharedState.activeSpace;
         const activeReqRef = treeItemsState.activeRequest;
 
         if (isActiveReqSavedToFs) {


### PR DESCRIPTION
- use structured error types
- replace most `.unwrap()`/`.expect()` calls with `Result` based handling
- use `CmdResult` for all tauri commands