### PR TITLE
refactor: standardize path handling with PathBuf and Path

### DIFF
--- a/scripts/sync-metadata/Cargo.lock
+++ b/scripts/sync-metadata/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "sync-metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/scripts/sync-metadata/Cargo.toml
+++ b/scripts/sync-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sync-metadata"
-version = "0.1.0"
-edition = "2021"
+version = "0.1.1"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1.0.210", features = ["derive"] }

--- a/scripts/sync-metadata/src/main.rs
+++ b/scripts/sync-metadata/src/main.rs
@@ -15,40 +15,42 @@ struct PackageJson {
 }
 
 fn main() -> std::io::Result<()> {
-    let package_json_path = PathBuf::from("./../../package.json");
-    let cargo_toml_path = PathBuf::from("./../../src-tauri/Cargo.toml");
-    let snapcraft_yaml_path = PathBuf::from("./../../snapcraft.yaml");
+    let root_path = PathBuf::from("..").join("..");
+    let pkgcfg_path = root_path.join("package.json");
+    let manifest_path = root_path.join("src-tauri").join("Cargo.toml");
+    let snapcfg_path = root_path.join("snapcraft.yaml");
 
-    let package_json_content = fs::read_to_string(package_json_path).unwrap();
-    let package_json: PackageJson = serde_json::from_str(&package_json_content).unwrap();
+    let pkgcfg_content = fs::read_to_string(pkgcfg_path).unwrap();
+    let pkgcfg: PackageJson = serde_json::from_str(&pkgcfg_content).unwrap();
 
-    let cargo_toml_content = fs::read_to_string(&cargo_toml_path).unwrap();
-    let mut cargo_toml: DocumentMut = cargo_toml_content.parse::<DocumentMut>().unwrap();
+    let manifest_content = fs::read_to_string(&manifest_path).unwrap();
+    let mut manifest: DocumentMut = manifest_content.parse::<DocumentMut>().unwrap();
 
-    cargo_toml["package"]["name"] = value(package_json.name.clone());
-    cargo_toml["package"]["version"] = value(package_json.version.clone());
-    cargo_toml["package"]["description"] = value(package_json.description.clone());
-    cargo_toml["package"]["license"] = value(package_json.license.clone());
+    manifest["package"]["name"] = value(pkgcfg.name.clone());
+    manifest["package"]["version"] = value(pkgcfg.version.clone());
+    manifest["package"]["description"] = value(pkgcfg.description.clone());
+    manifest["package"]["license"] = value(pkgcfg.license.clone());
 
     let mut authors_array = Array::new();
-    authors_array.push(package_json.author.clone());
-    cargo_toml["package"]["authors"] = value(authors_array);
+    authors_array.push(pkgcfg.author.clone());
+    manifest["package"]["authors"] = value(authors_array);
 
-    cargo_toml["package"]["repository"] = value(package_json.repository.clone());
-    cargo_toml["package"]["homepage"] = value(package_json.homepage.clone());
+    manifest["package"]["repository"] = value(pkgcfg.repository.clone());
+    manifest["package"]["homepage"] = value(pkgcfg.homepage.clone());
 
-    fs::write(&cargo_toml_path, cargo_toml.to_string()).unwrap();
+    fs::write(&manifest_path, manifest.to_string()).unwrap();
 
-    let snapcraft_yaml_content = fs::read_to_string(&snapcraft_yaml_path).unwrap();
-    let mut snapcraft_yaml: Value = from_str(&snapcraft_yaml_content).unwrap();
+    let snapcfg_content = fs::read_to_string(&snapcfg_path).unwrap();
+    let mut snapcfg: Value = from_str(&snapcfg_content).unwrap();
 
-    snapcraft_yaml["name"] = Value::String(package_json.name.clone());
-    snapcraft_yaml["version"] = Value::String(package_json.version.clone());
-    snapcraft_yaml["summary"] = Value::String(package_json.description.clone());
+    snapcfg["name"] = Value::String(pkgcfg.name.clone());
+    snapcfg["version"] = Value::String(pkgcfg.version.clone());
+    snapcfg["summary"] = Value::String(pkgcfg.description.clone());
 
-    let snapcraft_yaml_string = to_string(&snapcraft_yaml).unwrap();
-    fs::write(&snapcraft_yaml_path, snapcraft_yaml_string).unwrap();
+    let snapcfg_string = to_string(&snapcfg).unwrap();
+    fs::write(&snapcfg_path, snapcfg_string).unwrap();
 
     println!("Synced Cargo.toml and snapcraft.yaml metadata with package.json");
+
     Ok(())
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 authors = ["Mayank Verma <errmayank@gmail.com>"]
 repository = "https://github.com/buildzaku/zaku"
 homepage = "https://zaku.app"
-edition = "2021"
+edition = "2024"
 
 [build-dependencies]
 tauri-build = { version = "2.2.0", features = [] }

--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -202,32 +202,32 @@ pub fn create_parent_collections_if_missing(
     let segments = utils::to_sanitized_segments(relpath)?;
     let (last_segment, relpath_segments) = segments.split_last().unwrap();
 
-    let mut current_parent = location_relpath.to_path_buf();
+    let mut location_relpath = location_relpath.to_path_buf();
     for segment in relpath_segments {
-        let target_path = current_parent.join(&segment.fsname);
+        let target_path = location_relpath.join(&segment.fsname);
         let dir_abspath = space_abspath.join(&target_path);
 
         if !dir_abspath.exists() {
-            create_collection(&current_parent, segment, space_abspath)?;
+            create_collection(&location_relpath, segment, space_abspath)?;
         }
 
-        current_parent = target_path;
+        location_relpath = target_path;
     }
 
-    Ok((current_parent, last_segment.clone()))
+    Ok((location_relpath, last_segment.clone()))
 }
 
 /// Creates a new collection directory in the specified parent path
 ///
 /// Creates a new directory for the collection and saves the collection name mapping
 ///
-/// - `parent_relpath`: Relative path to the parent directory
+/// - `location_relpath`: Relative path of location where collection needs to be created
 /// - `col_segment`: Sanitized segment containing the collection name and filesystem name
 /// - `space_abspath`: Absolute path to the space directory
 ///
 /// Returns a `Result<CreateNewCollection>` containing the created collection's paths
 pub fn create_collection(
-    parent_relpath: &Path,
+    location_relpath: &Path,
     col_segment: &SanitizedSegment,
     space_abspath: &Path,
 ) -> Result<CreateNewCollection> {
@@ -237,8 +237,10 @@ pub fn create_collection(
         ));
     }
 
-    let col_abspath = space_abspath.join(parent_relpath).join(&col_segment.fsname);
-    let col_relpath = parent_relpath.join(&col_segment.fsname);
+    let col_abspath = space_abspath
+        .join(location_relpath)
+        .join(&col_segment.fsname);
+    let col_relpath = location_relpath.join(&col_segment.fsname);
 
     fs::create_dir(&col_abspath)?;
 
@@ -253,7 +255,7 @@ pub fn create_collection(
     })?;
 
     let create_new_collection = CreateNewCollection {
-        parent_relpath: parent_relpath.to_path_buf(),
+        location_relpath: location_relpath.to_path_buf(),
         relpath: col_relpath,
     };
 

--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -30,7 +30,7 @@ pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> 
         .unwrap_or(space_abspath.as_os_str())
         .to_string_lossy()
         .into_owned();
-    let relative_space_root = "".to_string();
+    let spaceroot_relpath = PathBuf::from("");
     let scmt_store = SpaceCollectionsMetadataStore::get(space_abspath)?;
 
     let sbf_store_abspath =
@@ -46,16 +46,14 @@ pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> 
             fsname: space_dirname,
             name: space_config.map(|config| config.meta.name),
             is_expanded: true,
+            relpath: spaceroot_relpath.clone(),
         },
         requests: Vec::new(),
         collections: Vec::new(),
     }));
 
     let mut stack: Vec<(PathBuf, Rc<RefCell<CollectionRcRefCell>>)> = Vec::new();
-    stack.push((
-        PathBuf::from(&relative_space_root),
-        Rc::clone(&root_collection_ref_cell),
-    ));
+    stack.push((spaceroot_relpath, Rc::clone(&root_collection_ref_cell)));
 
     while let Some((path, collection_rc_refcell)) = stack.pop() {
         if let Ok(entries) = fs::read_dir(space_abspath.join(&path)) {
@@ -83,22 +81,19 @@ pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> 
                         continue;
                     }
 
-                    let relpath = entry_abspath.strip_prefix(space_abspath).unwrap();
-
+                    let relpath = entry_abspath.strip_prefix(space_abspath)?.to_path_buf();
                     let sub_collection = Rc::new(RefCell::new(CollectionRcRefCell {
                         meta: CollectionMeta {
                             fsname: name,
-                            name: scmt_store
-                                .mappings
-                                .get(&relpath.to_string_lossy().to_string())
-                                .cloned(),
+                            name: scmt_store.mappings.get(&relpath).cloned(),
                             is_expanded: true,
+                            relpath: relpath.clone(),
                         },
                         requests: Vec::new(),
                         collections: Vec::new(),
                     }));
 
-                    stack.push((relpath.to_path_buf(), Rc::clone(&sub_collection)));
+                    stack.push((relpath, Rc::clone(&sub_collection)));
                     collection_rc_refcell
                         .borrow_mut()
                         .collections
@@ -201,14 +196,13 @@ pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> 
 /// Returns a `Result<(PathBuf, SanitizedSegment)>` with the final parent path and target segment
 pub fn create_parent_collections_if_missing(
     location_relpath: &Path,
-    relpath: &str,
+    relpath: &Path,
     space_abspath: &Path,
 ) -> Result<(PathBuf, SanitizedSegment)> {
     let segments = utils::to_sanitized_segments(relpath)?;
     let (last_segment, relpath_segments) = segments.split_last().unwrap();
 
     let mut current_parent = location_relpath.to_path_buf();
-
     for segment in relpath_segments {
         let target_path = current_parent.join(&segment.fsname);
         let dir_abspath = space_abspath.join(&target_path);
@@ -243,27 +237,24 @@ pub fn create_collection(
         ));
     }
 
-    let dir_abspath = space_abspath.join(parent_relpath).join(&col_segment.fsname);
-    let dir_relpath = parent_relpath.join(&col_segment.fsname);
+    let col_abspath = space_abspath.join(parent_relpath).join(&col_segment.fsname);
+    let col_relpath = parent_relpath.join(&col_segment.fsname);
 
-    fs::create_dir(&dir_abspath)?;
+    fs::create_dir(&col_abspath)?;
 
     let mut scmt_store = SpaceCollectionsMetadataStore::get(space_abspath)?;
     scmt_store.update(|metadata| {
-        let mapping_exists = metadata
-            .mappings
-            .contains_key(&dir_relpath.to_string_lossy().to_string());
+        let mapping_exists = metadata.mappings.contains_key(&col_relpath);
         if !mapping_exists {
-            metadata.mappings.insert(
-                dir_relpath.to_string_lossy().to_string(),
-                col_segment.name.clone(),
-            );
+            metadata
+                .mappings
+                .insert(col_relpath.clone(), col_segment.name.clone());
         }
     })?;
 
     let create_new_collection = CreateNewCollection {
-        parent_relpath: parent_relpath.to_string_lossy().to_string(),
-        relpath: dir_relpath.to_string_lossy().to_string(),
+        parent_relpath: parent_relpath.to_path_buf(),
+        relpath: col_relpath,
     };
 
     Ok(create_new_collection)

--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -200,7 +200,6 @@ pub fn create_parent_collections_if_missing(
     space_abspath: &Path,
 ) -> Result<(PathBuf, SanitizedSegment)> {
     let segments = utils::to_sanitized_segments(relpath)?;
-    eprintln!("{:?}", segments);
     let (last_segment, relpath_segments) = segments.split_last().unwrap();
 
     let mut current_parent = location_relpath.to_path_buf();

--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -200,6 +200,7 @@ pub fn create_parent_collections_if_missing(
     space_abspath: &Path,
 ) -> Result<(PathBuf, SanitizedSegment)> {
     let segments = utils::to_sanitized_segments(relpath)?;
+    eprintln!("{:?}", segments);
     let (last_segment, relpath_segments) = segments.split_last().unwrap();
 
     let mut current_parent = location_relpath.to_path_buf();

--- a/src-tauri/src/collection/models.rs
+++ b/src-tauri/src/collection/models.rs
@@ -17,6 +17,7 @@ pub struct CollectionMeta {
     pub fsname: String,
     pub name: Option<String>,
     pub is_expanded: bool,
+    pub relpath: PathBuf,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
@@ -29,13 +30,13 @@ pub struct Collection {
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateCollectionDto {
     pub location_relpath: PathBuf,
-    pub relpath: String,
+    pub relpath: PathBuf,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateNewCollection {
-    pub parent_relpath: String,
-    pub relpath: String,
+    pub parent_relpath: PathBuf,
+    pub relpath: PathBuf,
 }
 
 #[derive(Clone, Debug)]
@@ -47,7 +48,7 @@ pub struct CollectionRcRefCell {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SpaceCollectionsMetadata {
-    pub mappings: BTreeMap<String, String>,
+    pub mappings: BTreeMap<PathBuf, String>,
 }
 
 #[derive(Debug)]

--- a/src-tauri/src/collection/models.rs
+++ b/src-tauri/src/collection/models.rs
@@ -35,7 +35,7 @@ pub struct CreateCollectionDto {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateNewCollection {
-    pub parent_relpath: PathBuf,
+    pub location_relpath: PathBuf,
     pub relpath: PathBuf,
 }
 

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -320,15 +320,19 @@ fn create_parent_collections_if_missing_basic() {
     assert_eq!(col_segment.fsname, "grand-child-col-1");
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
-    assert!(!tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
+    assert!(
+        !tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .join("grand-child-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -416,10 +420,12 @@ fn create_collection_basic() {
         result.relpath.to_string_lossy().to_string(),
         expected_relpath.to_string_lossy().to_string()
     );
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -478,10 +484,12 @@ fn create_collection_unicode_path_should_succeed() {
         result.relpath.to_string_lossy().to_string(),
         expected_relpath.to_string_lossy().to_string()
     );
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("ザク-unicode-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("ザク-unicode-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -514,10 +522,12 @@ fn create_collection_should_save_collections_metadata() {
         result.relpath.to_string_lossy().to_string(),
         expected_relpath.to_string_lossy().to_string()
     );
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -547,15 +557,19 @@ fn create_collection_integrated_flow() {
     );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .join("grand-child-col-1")
+            .exists()
+    );
 
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
 

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use crate::{
@@ -29,68 +29,68 @@ fn parse_root_collection_should_match_created_structure() {
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from("parent-col-2"),
-            relpath: "Child Col 1/Grand Child Col 1".into(),
+            relpath: PathBuf::from("Child Col 1").join("Grand Child Col 1"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Parent Col 3/Child Col 2".into(),
+            relpath: PathBuf::from("Parent Col 3").join("Child Col 2"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Tilde ~~~ Parent Col 1/Back\\Slash Child Col 1  ".into(),
+            relpath: PathBuf::from("Tilde ~~~ Parent Col 1").join("Back\\Slash Child Col 1  "),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath:
-                "⚠️ ザク Unicode Parent Col 1/🔥 Emoji Child Col 1/💬 Emoji Grand Child Col 1?"
-                    .into(),
+            relpath: PathBuf::from("⚠️ ザク Unicode Parent Col 1")
+                .join("🔥 Emoji Child Col 1")
+                .join("💬 Emoji Grand Child Col 1?"),
         },
     ];
 
     let requests_dto = vec![
         CreateRequestDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Child Req 1".into(),
+            relpath: PathBuf::from("Child Req 1"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Parent Col 1/Child Req 2".into(),
+            relpath: PathBuf::from("Parent Col 1").join("Child Req 2"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-1"),
-            relpath: "Parent Req 1".into(),
+            relpath: PathBuf::from("Parent Req 1"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-2"),
-            relpath: "Parent Req 2".into(),
+            relpath: PathBuf::from("Parent Req 2"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-2").join("child-col-1"),
-            relpath: "Child Req 3".into(),
+            relpath: PathBuf::from("Child Req 3"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-2")
                 .join("child-col-1")
                 .join("grand-child-col-1"),
-            relpath: "Grand Child Req 1".into(),
+            relpath: PathBuf::from("Grand Child Req 1"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-3").join("child-col-2"),
-            relpath: "Child Req 4".into(),
+            relpath: PathBuf::from("Child Req 4"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("tilde-parent-col-1").join("back-slash-child-col-1"),
-            relpath: "Grand Child Col 1/Special*&Chars Req 1".into(),
+            relpath: PathBuf::from("Grand Child Col 1").join("Special*&Chars Req 1"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("ザク-unicode-parent-col-1")
                 .join("emoji-child-col-1")
                 .join("emoji-grand-child-col-1"),
-            relpath: "💡Emoji Special: Col 1/*>?Special Chars Req 1".into(),
+            relpath: PathBuf::from("💡Emoji Special: Col 1").join("*>?Special Chars Req 1"),
         },
     ];
 
-    let expected_colnames = HashMap::from([
+    let expected_colnames: HashMap<PathBuf, &'static str> = HashMap::from([
         (PathBuf::from("parent-col-1"), "Parent Col 1"),
         (PathBuf::from("parent-col-2"), "Parent Col 2"),
         (
@@ -115,7 +115,7 @@ fn parse_root_collection_should_match_created_structure() {
         ),
     ]);
 
-    let expected_reqnames = HashMap::from([
+    let expected_reqnames: HashMap<PathBuf, &'static str> = HashMap::from([
         (PathBuf::from("child-req-1.toml"), "Child Req 1"),
         (
             PathBuf::from("parent-col-1").join("child-req-2.toml"),
@@ -169,11 +169,10 @@ fn parse_root_collection_should_match_created_structure() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     for col_dto in &collections_dto {
-        let location_relpath = Path::new(&col_dto.location_relpath);
-        let relpath = &col_dto.relpath;
+        let location_relpath = PathBuf::from(&col_dto.location_relpath);
         let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-            location_relpath,
-            relpath,
+            &location_relpath,
+            &col_dto.relpath,
             &tmp_space_abspath,
         )
         .expect("Failed to create parent collections");
@@ -183,11 +182,10 @@ fn parse_root_collection_should_match_created_structure() {
     }
 
     for req_dto in &requests_dto {
-        let location_relpath = Path::new(&req_dto.location_relpath);
-        let relpath = &req_dto.relpath;
+        let location_relpath = PathBuf::from(&req_dto.location_relpath);
         let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-            location_relpath,
-            relpath,
+            &location_relpath,
+            &req_dto.relpath,
             &tmp_space_abspath,
         )
         .expect("Failed to create parent collections");
@@ -251,10 +249,9 @@ fn collections_metadata_reads_existing_data() {
     let toml_path = store::utils::scmt_store_abspath(&tmp_space_abspath);
 
     std::fs::create_dir_all(toml_path.parent().unwrap()).unwrap();
-    let collection_relpath_str = collection_relpath.to_string_lossy().to_string();
 
     let mut mappings = BTreeMap::new();
-    mappings.insert(collection_relpath_str.clone(), "Child Col 1".to_string());
+    mappings.insert(collection_relpath.clone(), "Child Col 1".to_string());
 
     let metadata = SpaceCollectionsMetadata { mappings };
     let toml_content = toml::to_string_pretty(&metadata).unwrap();
@@ -263,7 +260,7 @@ fn collections_metadata_reads_existing_data() {
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
 
     assert_eq!(
-        scmt_store.mappings.get(&collection_relpath_str),
+        scmt_store.mappings.get(&collection_relpath),
         Some(&"Child Col 1".to_string())
     );
 }
@@ -292,7 +289,7 @@ fn collections_metadata_creates_file_if_missing() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
-    let name = scmt_store.mappings.get("any-path");
+    let name = scmt_store.mappings.get(&PathBuf::from("any-path"));
     assert_eq!(name, None);
 
     let scmt_abspath = store::utils::scmt_store_abspath(&tmp_space_abspath);
@@ -307,11 +304,12 @@ fn create_parent_collections_if_missing_basic() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/Child Col 1/Grand Child Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -338,11 +336,10 @@ fn create_parent_collections_if_missing_single_segment() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Single Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Single Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -357,20 +354,18 @@ fn create_parent_collections_if_missing_duplicate_should_not_fail() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Duplicate Col 1/Duplicate Col 2";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath1, col_segment1) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Duplicate Col 1").join("Duplicate Col 2"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections first time");
 
-    let location_relpath = Path::new("");
-    let relpath = "Duplicate Col 1/Duplicate Col 2";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath2, col_segment2) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Duplicate Col 1").join("Duplicate Col 2"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections second time");
@@ -385,11 +380,12 @@ fn create_parent_collections_if_missing_special_chars_only_should_fail() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/!@#$%/Grand Child Col 1";
+    let location_relpath = PathBuf::from("");
     let result = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("!@#$%")
+            .join("Grand Child Col 1"),
         &tmp_space_abspath,
     );
 
@@ -408,12 +404,18 @@ fn create_collection_basic() {
         fsname: "child-col-1".to_string(),
     };
 
-    let result =
-        collection::create_collection(Path::new("parent-col-1"), &col_segment, &tmp_space_abspath)
-            .expect("Failed to create collection");
+    let result = collection::create_collection(
+        &PathBuf::from("parent-col-1"),
+        &col_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create collection");
 
     let expected_relpath = PathBuf::from("parent-col-1").join("child-col-1");
-    assert_eq!(result.relpath, expected_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_relpath.to_string_lossy().to_string()
+    );
     assert!(tmp_space_abspath
         .join("parent-col-1")
         .join("child-col-1")
@@ -430,8 +432,11 @@ fn create_collection_empty_fsname_should_fail() {
         fsname: "   ".to_string(),
     };
 
-    let result =
-        collection::create_collection(Path::new("parent-col-1"), &col_segment, &tmp_space_abspath);
+    let result = collection::create_collection(
+        &PathBuf::from("parent-col-1"),
+        &col_segment,
+        &tmp_space_abspath,
+    );
     assert!(matches!(result, Err(Error::InvalidName(_))));
 }
 
@@ -445,7 +450,7 @@ fn create_collection_missing_space_should_fail() {
     let tmp_dir = tempfile::tempdir().unwrap();
     let space_abspath = tmp_dir.path();
     let result =
-        collection::create_collection(Path::new("parent-col-1"), &col_segment, space_abspath);
+        collection::create_collection(&PathBuf::from("parent-col-1"), &col_segment, space_abspath);
     assert!(matches!(result, Err(Error::Io(_))));
 }
 
@@ -461,12 +466,18 @@ fn create_collection_unicode_path_should_succeed() {
         fsname: "ザク-unicode-col-1".to_string(),
     };
 
-    let result =
-        collection::create_collection(Path::new("parent-col-1"), &col_segment, &tmp_space_abspath)
-            .expect("Failed to create collection");
+    let result = collection::create_collection(
+        &PathBuf::from("parent-col-1"),
+        &col_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create collection");
 
     let expected_relpath = PathBuf::from("parent-col-1").join("ザク-unicode-col-1");
-    assert_eq!(result.relpath, expected_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_relpath.to_string_lossy().to_string()
+    );
     assert!(tmp_space_abspath
         .join("parent-col-1")
         .join("ザク-unicode-col-1")
@@ -485,20 +496,24 @@ fn create_collection_should_save_collections_metadata() {
         fsname: "child-col-1".to_string(),
     };
 
-    let result =
-        collection::create_collection(Path::new("parent-col-1"), &col_segment, &tmp_space_abspath)
-            .expect("Failed to create collection");
+    let result = collection::create_collection(
+        &PathBuf::from("parent-col-1"),
+        &col_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create collection");
 
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
     let expected_relpath = PathBuf::from("parent-col-1").join("child-col-1");
 
     assert_eq!(
-        scmt_store
-            .mappings
-            .get(&expected_relpath.to_string_lossy().to_string()),
+        scmt_store.mappings.get(&expected_relpath),
         Some(&"Child Col 1".to_string())
     );
-    assert_eq!(result.relpath, expected_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_relpath.to_string_lossy().to_string()
+    );
     assert!(tmp_space_abspath
         .join("parent-col-1")
         .join("child-col-1")
@@ -510,11 +525,12 @@ fn create_collection_integrated_flow() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/Child Col 1/Grand Child Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -525,7 +541,10 @@ fn create_collection_integrated_flow() {
     let expected_relpath = PathBuf::from("parent-col-1")
         .join("child-col-1")
         .join("grand-child-col-1");
-    assert_eq!(result.relpath, expected_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_relpath.to_string_lossy().to_string()
+    );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
     assert!(tmp_space_abspath
@@ -547,21 +566,15 @@ fn create_collection_integrated_flow() {
         .join("grand-child-col-1");
 
     assert_eq!(
-        scmt_store
-            .mappings
-            .get(&parent_relpath.to_string_lossy().to_string()),
+        scmt_store.mappings.get(&parent_relpath),
         Some(&"Parent Col 1".to_string())
     );
     assert_eq!(
-        scmt_store
-            .mappings
-            .get(&child_relpath.to_string_lossy().to_string()),
+        scmt_store.mappings.get(&child_relpath),
         Some(&"Child Col 1".to_string())
     );
     assert_eq!(
-        scmt_store
-            .mappings
-            .get(&grandchild_relpath.to_string_lossy().to_string()),
+        scmt_store.mappings.get(&grandchild_relpath),
         Some(&"Grand Child Col 1".to_string())
     );
 }

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -168,27 +168,27 @@ fn parse_root_collection_should_match_created_structure() {
 
     for col_dto in &collections_dto {
         let location_relpath = PathBuf::from(&col_dto.location_relpath);
-        let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+        let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
             &location_relpath,
             &col_dto.relpath,
             &tmp_space_abspath,
         )
         .expect("Failed to create parent collections");
 
-        collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+        collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
             .expect("Failed to create collection");
     }
 
     for req_dto in &requests_dto {
         let location_relpath = PathBuf::from(&req_dto.location_relpath);
-        let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+        let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
             &location_relpath,
             &req_dto.relpath,
             &tmp_space_abspath,
         )
         .expect("Failed to create parent collections");
 
-        request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+        request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
             .expect("Failed to create request");
     }
 
@@ -303,7 +303,7 @@ fn create_parent_collections_if_missing_basic() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
         &tmp_space_abspath,
@@ -311,7 +311,7 @@ fn create_parent_collections_if_missing_basic() {
     .expect("Failed to create parent collections");
 
     assert_eq!(
-        parent_relpath,
+        location_relpath,
         PathBuf::from("parent-col-1").join("child-col-1")
     );
     assert_eq!(col_segment.name, "Grand Child Col 1");
@@ -338,14 +338,14 @@ fn create_parent_collections_if_missing_with_nested_backslash() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1/Child Col 1\\Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    assert_eq!(parent_relpath, PathBuf::from("parent-col-1"));
+    assert_eq!(location_relpath, PathBuf::from("parent-col-1"));
     assert_eq!(col_segment.name, "Child Col 1-Grand Child Col 1");
     assert_eq!(col_segment.fsname, "child-col-1-grand-child-col-1");
 
@@ -358,14 +358,14 @@ fn create_parent_collections_if_missing_single_segment() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Single Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    assert_eq!(parent_relpath, PathBuf::from(""));
+    assert_eq!(location_relpath, PathBuf::from(""));
     assert_eq!(col_segment.name, "Single Col 1");
     assert_eq!(col_segment.fsname, "single-col-1");
 }
@@ -376,7 +376,7 @@ fn create_parent_collections_if_missing_duplicate_should_not_fail() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath1, col_segment1) = collection::create_parent_collections_if_missing(
+    let (location_relpath1, col_segment1) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Duplicate Col 1/Duplicate Col 2"),
         &tmp_space_abspath,
@@ -384,14 +384,14 @@ fn create_parent_collections_if_missing_duplicate_should_not_fail() {
     .expect("Failed to create parent collections first time");
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath2, col_segment2) = collection::create_parent_collections_if_missing(
+    let (location_relpath2, col_segment2) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Duplicate Col 1/Duplicate Col 2"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections second time");
 
-    assert_eq!(parent_relpath1, parent_relpath2);
+    assert_eq!(location_relpath1, location_relpath2);
     assert_eq!(col_segment1.name, col_segment2.name);
     assert_eq!(col_segment1.fsname, col_segment2.fsname);
 }
@@ -546,14 +546,14 @@ fn create_collection_integrated_flow() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    let result = collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
     assert_eq!(
@@ -580,12 +580,12 @@ fn create_collection_integrated_flow() {
 
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
 
-    let parent_relpath = PathBuf::from("parent-col-1");
+    let location_relpath = PathBuf::from("parent-col-1");
     let child_relpath = PathBuf::from("parent-col-1/child-col-1");
     let grandchild_relpath = PathBuf::from("parent-col-1/child-col-1/grand-child-col-1");
 
     assert_eq!(
-        scmt_store.mappings.get(&parent_relpath),
+        scmt_store.mappings.get(&location_relpath),
         Some(&"Parent Col 1".to_string())
     );
     assert_eq!(

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -334,6 +334,25 @@ fn create_parent_collections_if_missing_basic() {
 }
 
 #[test]
+fn create_parent_collections_if_missing_with_nested_backslash() {
+    let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
+    let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
+
+    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+        &PathBuf::from(""),
+        &PathBuf::from("Parent Col 1/Child Col 1\\Grand Child Col 1"),
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create parent collections");
+
+    assert_eq!(parent_relpath, PathBuf::from("parent-col-1"));
+    assert_eq!(col_segment.name, "Child Col 1-Grand Child Col 1");
+    assert_eq!(col_segment.fsname, "child-col-1-grand-child-col-1");
+
+    assert!(tmp_space_abspath.join("parent-col-1").exists());
+}
+
+#[test]
 fn create_parent_collections_if_missing_single_segment() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -21,29 +21,29 @@ fn parse_root_collection_should_match_created_structure() {
     let collections_dto = vec![
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Parent Col 1".into(),
+            relpath: PathBuf::from("Parent Col 1"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: "Parent Col 2".into(),
+            relpath: PathBuf::from("Parent Col 2"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from("parent-col-2"),
-            relpath: PathBuf::from("Child Col 1").join("Grand Child Col 1"),
+            relpath: PathBuf::from("Child Col 1/Grand Child Col 1"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: PathBuf::from("Parent Col 3").join("Child Col 2"),
+            relpath: PathBuf::from("Parent Col 3/Child Col 2"),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: PathBuf::from("Tilde ~~~ Parent Col 1").join("Back\\Slash Child Col 1  "),
+            relpath: PathBuf::from("Tilde ~~~ Parent Col 1/Back\\Slash Child Col 1  "),
         },
         CreateCollectionDto {
             location_relpath: PathBuf::from(""),
-            relpath: PathBuf::from("⚠️ ザク Unicode Parent Col 1")
-                .join("🔥 Emoji Child Col 1")
-                .join("💬 Emoji Grand Child Col 1?"),
+            relpath: PathBuf::from(
+                "⚠️ ザク Unicode Parent Col 1/🔥 Emoji Child Col 1/💬 Emoji Grand Child Col 1?",
+            ),
         },
     ];
 
@@ -54,7 +54,7 @@ fn parse_root_collection_should_match_created_structure() {
         },
         CreateRequestDto {
             location_relpath: PathBuf::from(""),
-            relpath: PathBuf::from("Parent Col 1").join("Child Req 2"),
+            relpath: PathBuf::from("Parent Col 1/Child Req 2"),
         },
         CreateRequestDto {
             location_relpath: PathBuf::from("parent-col-1"),
@@ -65,28 +65,26 @@ fn parse_root_collection_should_match_created_structure() {
             relpath: PathBuf::from("Parent Req 2"),
         },
         CreateRequestDto {
-            location_relpath: PathBuf::from("parent-col-2").join("child-col-1"),
+            location_relpath: PathBuf::from("parent-col-2/child-col-1"),
             relpath: PathBuf::from("Child Req 3"),
         },
         CreateRequestDto {
-            location_relpath: PathBuf::from("parent-col-2")
-                .join("child-col-1")
-                .join("grand-child-col-1"),
+            location_relpath: PathBuf::from("parent-col-2/child-col-1/grand-child-col-1"),
             relpath: PathBuf::from("Grand Child Req 1"),
         },
         CreateRequestDto {
-            location_relpath: PathBuf::from("parent-col-3").join("child-col-2"),
+            location_relpath: PathBuf::from("parent-col-3/child-col-2"),
             relpath: PathBuf::from("Child Req 4"),
         },
         CreateRequestDto {
-            location_relpath: PathBuf::from("tilde-parent-col-1").join("back-slash-child-col-1"),
-            relpath: PathBuf::from("Grand Child Col 1").join("Special*&Chars Req 1"),
+            location_relpath: PathBuf::from("tilde-parent-col-1/back-slash-child-col-1"),
+            relpath: PathBuf::from("Grand Child Col 1/Special*&Chars Req 1"),
         },
         CreateRequestDto {
-            location_relpath: PathBuf::from("ザク-unicode-parent-col-1")
-                .join("emoji-child-col-1")
-                .join("emoji-grand-child-col-1"),
-            relpath: PathBuf::from("💡Emoji Special: Col 1").join("*>?Special Chars Req 1"),
+            location_relpath: PathBuf::from(
+                "ザク-unicode-parent-col-1/emoji-child-col-1/emoji-grand-child-col-1",
+            ),
+            relpath: PathBuf::from("💡Emoji Special: Col 1/*>?Special Chars Req 1"),
         },
     ];
 
@@ -245,7 +243,7 @@ fn collections_metadata_reads_existing_data() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Col Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let collection_relpath = PathBuf::from("parent-col-1").join("child-col-1");
+    let collection_relpath = PathBuf::from("parent-col-1/child-col-1");
     let toml_path = store::utils::scmt_store_abspath(&tmp_space_abspath);
 
     std::fs::create_dir_all(toml_path.parent().unwrap()).unwrap();
@@ -307,15 +305,15 @@ fn create_parent_collections_if_missing_basic() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Grand Child Col 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let expected_parent = PathBuf::from("parent-col-1").join("child-col-1");
-    assert_eq!(parent_relpath, expected_parent);
+    assert_eq!(
+        parent_relpath,
+        PathBuf::from("parent-col-1").join("child-col-1")
+    );
     assert_eq!(col_segment.name, "Grand Child Col 1");
     assert_eq!(col_segment.fsname, "grand-child-col-1");
 
@@ -361,7 +359,7 @@ fn create_parent_collections_if_missing_duplicate_should_not_fail() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath1, col_segment1) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Duplicate Col 1").join("Duplicate Col 2"),
+        &PathBuf::from("Duplicate Col 1/Duplicate Col 2"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections first time");
@@ -369,7 +367,7 @@ fn create_parent_collections_if_missing_duplicate_should_not_fail() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath2, col_segment2) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Duplicate Col 1").join("Duplicate Col 2"),
+        &PathBuf::from("Duplicate Col 1/Duplicate Col 2"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections second time");
@@ -387,9 +385,7 @@ fn create_parent_collections_if_missing_special_chars_only_should_fail() {
     let location_relpath = PathBuf::from("");
     let result = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("!@#$%")
-            .join("Grand Child Col 1"),
+        &PathBuf::from("Parent Col 1/!@#$%/Grand Child Col 1"),
         &tmp_space_abspath,
     );
 
@@ -415,10 +411,9 @@ fn create_collection_basic() {
     )
     .expect("Failed to create collection");
 
-    let expected_relpath = PathBuf::from("parent-col-1").join("child-col-1");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("child-col-1")
     );
     assert!(
         tmp_space_abspath
@@ -479,10 +474,9 @@ fn create_collection_unicode_path_should_succeed() {
     )
     .expect("Failed to create collection");
 
-    let expected_relpath = PathBuf::from("parent-col-1").join("ザク-unicode-col-1");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("ザク-unicode-col-1")
     );
     assert!(
         tmp_space_abspath
@@ -518,10 +512,7 @@ fn create_collection_should_save_collections_metadata() {
         scmt_store.mappings.get(&expected_relpath),
         Some(&"Child Col 1".to_string())
     );
-    assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_relpath.to_string_lossy().to_string()
-    );
+    assert_eq!(result.relpath, expected_relpath);
     assert!(
         tmp_space_abspath
             .join("parent-col-1")
@@ -538,9 +529,7 @@ fn create_collection_integrated_flow() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Grand Child Col 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -548,12 +537,11 @@ fn create_collection_integrated_flow() {
     let result = collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
-    let expected_relpath = PathBuf::from("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-col-1");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1")
+            .join("child-col-1")
+            .join("grand-child-col-1")
     );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
@@ -574,10 +562,8 @@ fn create_collection_integrated_flow() {
     let scmt_store = SpaceCollectionsMetadataStore::get(&tmp_space_abspath).unwrap();
 
     let parent_relpath = PathBuf::from("parent-col-1");
-    let child_relpath = PathBuf::from("parent-col-1").join("child-col-1");
-    let grandchild_relpath = PathBuf::from("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-col-1");
+    let child_relpath = PathBuf::from("parent-col-1/child-col-1");
+    let grandchild_relpath = PathBuf::from("parent-col-1/child-col-1/grand-child-col-1");
 
     assert_eq!(
         scmt_store.mappings.get(&parent_relpath),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -108,7 +108,7 @@ pub async fn create_collection(dto: CreateCollectionDto) -> CmdResult<CreateNewC
         .abspath
         .clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &dto.location_relpath,
         &dto.relpath,
         &space_abspath,
@@ -119,7 +119,7 @@ pub async fn create_collection(dto: CreateCollectionDto) -> CmdResult<CreateNewC
         details: Some(err.to_string()),
     })?;
 
-    collection::create_collection(&parent_relpath, &col_segment, &space_abspath).map_err(|err| {
+    collection::create_collection(&location_relpath, &col_segment, &space_abspath).map_err(|err| {
         CmdErr {
             kind: ErrorKind::FileWriteError,
             message: "Unable to create collection".to_string(),
@@ -231,7 +231,7 @@ pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
         .abspath
         .clone();
 
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &dto.location_relpath,
         &dto.relpath,
         &space_abspath,
@@ -242,7 +242,7 @@ pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
         details: Some(err.to_string()),
     })?;
 
-    request::create_req(&parent_relpath, &req_segment, &space_abspath).map_err(|err| CmdErr {
+    request::create_req(&location_relpath, &req_segment, &space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
         message: "Unable to create request".to_string(),
         details: Some(err.to_string()),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,11 +1,6 @@
 use cookie::Cookie as RawCookie;
 use dirs;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::OnceLock,
-    time::Instant,
-};
+use std::{collections::HashMap, path::PathBuf, sync::OnceLock, time::Instant};
 use tauri::Manager;
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_notification::{NotificationExt, PermissionState};
@@ -117,7 +112,7 @@ pub async fn create_collection(dto: CreateCollectionDto) -> CmdResult<CreateNewC
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &dto.location_relpath,
         &dto.relpath,
-        Path::new(&space_abspath),
+        &space_abspath,
     )
     .map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
@@ -125,13 +120,13 @@ pub async fn create_collection(dto: CreateCollectionDto) -> CmdResult<CreateNewC
         details: Some(err.to_string()),
     })?;
 
-    collection::create_collection(&parent_relpath, &col_segment, Path::new(&space_abspath)).map_err(
-        |err| CmdErr {
+    collection::create_collection(&parent_relpath, &col_segment, &space_abspath).map_err(|err| {
+        CmdErr {
             kind: ErrorKind::FileWriteError,
             message: "Unable to create collection".to_string(),
             details: Some(err.to_string()),
-        },
-    )
+        }
+    })
 }
 
 #[specta::specta]
@@ -240,7 +235,7 @@ pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &dto.location_relpath,
         &dto.relpath,
-        Path::new(&space_abspath),
+        &space_abspath,
     )
     .map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
@@ -248,24 +243,17 @@ pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
         details: Some(err.to_string()),
     })?;
 
-    request::create_req(&parent_relpath, &req_segment, Path::new(&space_abspath)).map_err(|err| {
-        CmdErr {
-            kind: ErrorKind::FileWriteError,
-            message: "Unable to create request".to_string(),
-            details: Some(err.to_string()),
-        }
+    request::create_req(&parent_relpath, &req_segment, &space_abspath).map_err(|err| CmdErr {
+        kind: ErrorKind::FileWriteError,
+        message: "Unable to create request".to_string(),
+        details: Some(err.to_string()),
     })
 }
 
 #[specta::specta]
 #[tauri::command]
-pub async fn write_req_to_space_buffer(
-    space_abspath: &str,
-    relpath: &str,
-    request: HttpReq,
-) -> CmdResult<()> {
-    let sbf_store_abspath =
-        store::utils::sbf_store_abspath(&datadir_abspath(), Path::new(space_abspath));
+pub async fn write_req_to_space_buffer(space_abspath: PathBuf, request: HttpReq) -> CmdResult<()> {
+    let sbf_store_abspath = store::utils::sbf_store_abspath(&datadir_abspath(), &space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space buffer".to_string(),
@@ -275,13 +263,11 @@ pub async fn write_req_to_space_buffer(
     SpaceBufferStore::update(&sbf_store, |sbf_store| {
         let mut sbf_store_mtx = sbf_store.lock().expect("Failed to lock SpaceBufferStore");
 
-        let req_relpath = Path::new(relpath)
-            .join(&request.meta.fsname)
-            .to_string_lossy()
-            .to_string();
         let req_buf = ReqBuffer::from_req(&request);
 
-        sbf_store_mtx.requests.insert(req_relpath, req_buf);
+        sbf_store_mtx
+            .requests
+            .insert(request.meta.relpath.clone(), req_buf);
     })
     .map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
@@ -294,8 +280,11 @@ pub async fn write_req_to_space_buffer(
 
 #[specta::specta]
 #[tauri::command]
-pub async fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) -> CmdResult<()> {
-    let space_abspath = Path::new(space_abspath);
+pub async fn write_reqbuf_to_reqtoml(
+    space_abspath: PathBuf,
+    req_relpath: PathBuf,
+) -> CmdResult<()> {
+    let space_abspath = &space_abspath;
     let sbf_store_abspath = store::utils::sbf_store_abspath(&datadir_abspath(), space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
@@ -306,13 +295,12 @@ pub async fn write_reqbuf_to_reqtoml(space_abspath: &str, req_relpath: &str) -> 
     SpaceBufferStore::update(&sbf_store, |sbf_store| {
         let mut sbf_store_mtx = sbf_store.lock().unwrap();
 
-        let relpath_str = Path::new(req_relpath).to_string_lossy().to_string();
-        if let Some(req_buf) = sbf_store_mtx.requests.get(&relpath_str) {
+        if let Some(req_buf) = sbf_store_mtx.requests.get(&req_relpath) {
             let req_toml = ReqToml::from_reqbuf(req_buf);
-            let _ = request::update_reqtoml(&space_abspath.join(req_relpath), &req_toml);
+            let _ = request::update_reqtoml(&space_abspath.join(&req_relpath), &req_toml);
         }
 
-        sbf_store_mtx.requests.remove(&relpath_str);
+        sbf_store_mtx.requests.remove(&req_relpath);
     })
     .map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
@@ -567,8 +555,8 @@ pub fn remove_space(space_reference: SpaceReference) -> CmdResult<()> {
 
 #[specta::specta]
 #[tauri::command]
-pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
-    let space_abspath = PathBuf::from(path.as_str());
+pub fn get_spaceref(path: PathBuf) -> CmdResult<SpaceReference> {
+    let space_abspath = path;
 
     match space::parse_spacecfg(&space_abspath) {
         Ok(space_config_file) => {
@@ -590,10 +578,9 @@ pub fn get_spaceref(path: String) -> CmdResult<SpaceReference> {
 #[specta::specta]
 #[tauri::command]
 pub async fn get_space_cookies(
-    space_abspath: &str,
+    space_abspath: PathBuf,
 ) -> CmdResult<HashMap<String, Vec<SerializedCookie>>> {
-    let sck_store_abspath =
-        store::utils::sck_store_abspath(&datadir_abspath(), Path::new(space_abspath));
+    let sck_store_abspath = store::utils::sck_store_abspath(&datadir_abspath(), &space_abspath);
     let sck_store = SpaceCookieStore::get(&sck_store_abspath).map_err(|e| CmdErr {
         kind: ErrorKind::CookieError,
         message: "Unable to load cookies".to_string(),
@@ -627,11 +614,10 @@ pub async fn get_space_cookies(
 
 #[specta::specta]
 #[tauri::command]
-pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> CmdResult<bool> {
+pub fn remove_cookie(space_abspath: PathBuf, rm_cookie_dto: RemoveCookieDto) -> CmdResult<bool> {
     let RemoveCookieDto { domain, path, name } = rm_cookie_dto;
 
-    let sck_store_abspath =
-        store::utils::sck_store_abspath(&datadir_abspath(), Path::new(space_abspath));
+    let sck_store_abspath = store::utils::sck_store_abspath(&datadir_abspath(), &space_abspath);
     let mut sck_store = SpaceCookieStore::get(&sck_store_abspath).map_err(|e| CmdErr {
         kind: ErrorKind::CookieError,
         message: "Unable to load cookies".to_string(),
@@ -654,11 +640,10 @@ pub fn remove_cookie(space_abspath: &str, rm_cookie_dto: RemoveCookieDto) -> Cmd
 #[specta::specta]
 #[tauri::command]
 pub async fn save_space_settings(
-    space_abspath: &str,
+    space_abspath: PathBuf,
     space_settings: SpaceSettings,
 ) -> CmdResult<()> {
-    let sst_store_abspath =
-        store::utils::sst_store_abspath(&datadir_abspath(), Path::new(space_abspath));
+    let sst_store_abspath = store::utils::sst_store_abspath(&datadir_abspath(), &space_abspath);
     let mut sst_store = SpaceSettingsStore::get(&sst_store_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space settings".to_string(),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,10 +22,9 @@ use crate::{
         models::{CreateSpaceDto, RemoveCookieDto, SerializedCookie, SpaceReference},
     },
     store::{
-        self,
+        self, ReqBuffer, SpaceCookieStore, SpaceSettings, StateStore,
         spaces::{buffer::SpaceBufferStore, settings::SpaceSettingsStore},
         state::SharedState,
-        ReqBuffer, SpaceCookieStore, SpaceSettings, StateStore,
     },
     tree_node::{self, MoveTreeNodeDto},
 };

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
@@ -14,6 +16,6 @@ pub struct DispatchNotificationOptions {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateNewRequest {
-    pub parent_relpath: String,
-    pub relpath: String,
+    pub parent_relpath: PathBuf,
+    pub relpath: PathBuf,
 }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -16,6 +16,6 @@ pub struct DispatchNotificationOptions {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateNewRequest {
-    pub parent_relpath: PathBuf,
+    pub location_relpath: PathBuf,
     pub relpath: PathBuf,
 }

--- a/src-tauri/src/error/mod.rs
+++ b/src-tauri/src/error/mod.rs
@@ -48,6 +48,9 @@ pub enum Error {
 
     #[from]
     ShortcutPlugin(tauri_plugin_global_shortcut::Error),
+
+    #[from]
+    StripPrefix(std::path::StripPrefixError),
 }
 
 impl fmt::Display for Error {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         .error_handling(tauri_specta::ErrorHandlingMode::Result);
 
     if std::env::var("GEN_BINDINGS").is_ok() {
-        use specta_typescript::{formatter, Typescript};
+        use specta_typescript::{Typescript, formatter};
 
         builder
             .export(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::path::PathBuf;
+
 pub mod collection;
 pub mod commands;
 pub mod error;
@@ -13,7 +15,12 @@ pub mod store;
 pub mod tree_node;
 pub mod utils;
 
-const BINDINGS_PATH: &str = "./../src/lib/bindings.ts";
+fn ts_bindings_path() -> PathBuf {
+    PathBuf::from("..")
+        .join("src")
+        .join("lib")
+        .join("bindings.ts")
+}
 
 fn main() {
     #[cfg(target_os = "linux")]
@@ -29,7 +36,7 @@ fn main() {
         builder
             .export(
                 Typescript::default().formatter(formatter::prettier),
-                BINDINGS_PATH,
+                ts_bindings_path(),
             )
             .expect("Failed to export typescript bindings");
     }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,5 +1,5 @@
 use rodio::{Decoder, OutputStream, Sink};
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, path::PathBuf};
 use tauri::{path::BaseDirectory, AppHandle, Manager};
 
 use crate::error::{Error, Result};
@@ -9,7 +9,10 @@ pub fn play_finish(app_handle: &AppHandle) -> Result<()> {
     let sink = Sink::try_new(&stream_handle)?;
     let sound_filepath = app_handle
         .path()
-        .resolve("assets/sounds/glass.wav", BaseDirectory::Resource)
+        .resolve(
+            PathBuf::from("assets").join("sounds").join("glass.wav"),
+            BaseDirectory::Resource,
+        )
         .map_err(|e| Error::FileNotFound(e.to_string()))?;
     let sound_file = File::open(sound_filepath)?;
     let source = Decoder::new(BufReader::new(sound_file))

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,6 +1,6 @@
 use rodio::{Decoder, OutputStream, Sink};
 use std::{fs::File, io::BufReader, path::PathBuf};
-use tauri::{path::BaseDirectory, AppHandle, Manager};
+use tauri::{AppHandle, Manager, path::BaseDirectory};
 
 use crate::error::{Error, Result};
 

--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 
 pub fn initialize() -> Result<()> {
     if has_nvidia_gpu() {
-        env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1"); // https://github.com/tauri-apps/tauri/issues/9304
+        unsafe { env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1") }; // https://github.com/tauri-apps/tauri/issues/9304
     }
 
     Ok(())

--- a/src-tauri/src/request/mod.rs
+++ b/src-tauri/src/request/mod.rs
@@ -62,13 +62,13 @@ pub fn parse_req(
 /// Creates a new TOML request file in the parent collection directory and updates
 /// the shared state
 ///
-/// - `parent_relpath`: Relative path to the parent collection directory
+/// - `location_relpath`: Relative path of location where request needs to be created
 /// - `req_segment`: Sanitized segment containing the request name and filesystem name
 /// - `space_abspath`: Absolute path to the space directory
 ///
 /// Returns a `Result<CreateNewRequest>` containing the created request's paths
 pub fn create_req(
-    parent_relpath: &Path,
+    location_relpath: &Path,
     req_segment: &SanitizedSegment,
     space_abspath: &Path,
 ) -> Result<CreateNewRequest> {
@@ -78,13 +78,15 @@ pub fn create_req(
         ));
     }
 
-    let reqfile_abspath = space_abspath.join(parent_relpath).join(&req_segment.fsname);
-    let reqfile_relpath = parent_relpath.join(format!("{}.toml", &req_segment.fsname));
+    let reqfile_abspath = space_abspath
+        .join(location_relpath)
+        .join(&req_segment.fsname);
+    let reqfile_relpath = location_relpath.join(format!("{}.toml", &req_segment.fsname));
 
     create_reqtoml(&reqfile_abspath, &req_segment.name)?;
 
     let created = CreateNewRequest {
-        parent_relpath: parent_relpath.to_path_buf(),
+        location_relpath: location_relpath.to_path_buf(),
         relpath: reqfile_relpath,
     };
 

--- a/src-tauri/src/request/mod.rs
+++ b/src-tauri/src/request/mod.rs
@@ -42,23 +42,12 @@ pub fn parse_req(
         return None;
     }
 
-    let relpath = entry_abspath
-        .strip_prefix(space_abspath)
-        .unwrap()
-        .to_string_lossy()
-        .into_owned();
-
-    if let Some(req_buf) = sbf_store_mtx.requests.get(&relpath) {
+    let relpath = entry_abspath.strip_prefix(space_abspath).ok()?;
+    if let Some(req_buf) = sbf_store_mtx.requests.get(relpath) {
         Some(HttpReq::from_reqbuf(req_buf))
     } else {
-        let fsname = entry_abspath
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-
         match parse_reqtoml(entry_abspath) {
-            Ok(req_toml) => Some(HttpReq::from_reqtoml(&req_toml, fsname)),
+            Ok(req_toml) => Some(HttpReq::from_reqtoml(&req_toml, relpath)),
             Err(_) => {
                 eprintln!("Invalid request TOML: '{}'", entry_abspath.display());
 
@@ -95,8 +84,8 @@ pub fn create_req(
     create_reqtoml(&reqfile_abspath, &req_segment.name)?;
 
     let created = CreateNewRequest {
-        parent_relpath: parent_relpath.to_string_lossy().to_string(),
-        relpath: reqfile_relpath.to_string_lossy().to_string(),
+        parent_relpath: parent_relpath.to_path_buf(),
+        relpath: reqfile_relpath,
     };
 
     Ok(created)

--- a/src-tauri/src/request/models.rs
+++ b/src-tauri/src/request/models.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,9 @@ pub struct ReqMeta {
     pub fsname: String,
     pub name: String,
     pub has_unsaved_changes: bool,
+    pub relpath: PathBuf,
 }
+
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct ReqUrl {
@@ -114,6 +116,7 @@ impl HttpReq {
             fsname: req_buf.meta.fsname.clone(),
             name: req_buf.meta.name.clone(),
             has_unsaved_changes: req_buf.meta.has_unsaved_changes,
+            relpath: req_buf.meta.relpath.clone(),
         };
 
         Self {
@@ -124,11 +127,18 @@ impl HttpReq {
         }
     }
 
-    pub fn from_reqtoml(req_toml: &ReqToml, fsname: String) -> Self {
+    pub fn from_reqtoml(req_toml: &ReqToml, relpath: &Path) -> Self {
+        let fsname = relpath
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+            
         let meta = ReqMeta {
             fsname,
             name: req_toml.meta.name.clone(),
             has_unsaved_changes: false,
+            relpath: relpath.to_path_buf(),
         };
 
         let cfg = &req_toml.config;
@@ -173,7 +183,7 @@ impl HttpReq {
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateRequestDto {
     pub location_relpath: PathBuf,
-    pub relpath: String,
+    pub relpath: PathBuf,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]

--- a/src-tauri/src/request/models.rs
+++ b/src-tauri/src/request/models.rs
@@ -19,7 +19,6 @@ pub struct ReqMeta {
     pub relpath: PathBuf,
 }
 
-
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct ReqUrl {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -128,12 +127,8 @@ impl HttpReq {
     }
 
     pub fn from_reqtoml(req_toml: &ReqToml, relpath: &Path) -> Self {
-        let fsname = relpath
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-            
+        let fsname = relpath.file_name().unwrap().to_string_lossy().into_owned();
+
         let meta = ReqMeta {
             fsname,
             name: req_toml.meta.name.clone(),

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -191,14 +191,14 @@ fn create_req_with_nested_collections() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Grand Parent Col 1/Parent Col 1/Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with nested collections");
 
     assert_eq!(
@@ -229,14 +229,14 @@ fn create_req_with_nested_collections_and_backslash() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Grand Parent Col 1\\Parent Col 1\\Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with nested collections");
 
     assert_eq!(
@@ -768,14 +768,14 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with deep hierarchy");
 
     assert_eq!(
@@ -848,14 +848,14 @@ fn create_req_with_trailing_slash_in_relpath() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Parent Col 1/Child Col 1/Trailing Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with trailing slash");
 
     assert_eq!(
@@ -932,14 +932,14 @@ fn create_req_with_multiple_slashes_in_relpath() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Parent Col 1/Child Col 1/Multiple Slash Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with multiple slashes");
 
     assert_eq!(
@@ -956,14 +956,14 @@ fn create_req_integrated_flow() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
         &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+    let result = request::create_req(&location_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
     assert_eq!(

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 
 use crate::{
     collection,
@@ -118,6 +115,7 @@ fn parse_req_returns_buffered_request_when_available() {
                 fsname: "buffered-req-1.toml".to_string(),
                 name: "Modified Buffered Req 1".to_string(),
                 has_unsaved_changes: true,
+                relpath: PathBuf::from("buffered-req-1.toml"),
             },
             config: ReqCfg {
                 method: "POST".to_string(),
@@ -136,7 +134,7 @@ fn parse_req_returns_buffered_request_when_available() {
 
         sbf_store_mtx
             .requests
-            .insert("buffered-req-1.toml".to_string(), req_buf);
+            .insert(PathBuf::from("buffered-req-1.toml"), req_buf);
     }
 
     let sbf_store_mtx = sbf_store
@@ -165,11 +163,18 @@ fn create_req_basic() {
         fsname: "child-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request");
 
     let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("child-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -186,11 +191,12 @@ fn create_req_with_nested_collections() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Grand Parent Col 1/Parent Col 1/Child Req 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Grand Parent Col 1")
+            .join("Parent Col 1")
+            .join("Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -201,7 +207,10 @@ fn create_req_with_nested_collections() {
     let expected_reqfile_relpath = PathBuf::from("grand-parent-col-1")
         .join("parent-col-1")
         .join("child-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("grand-parent-col-1")
@@ -226,7 +235,11 @@ fn create_req_empty_fsname_should_fail() {
         fsname: "   ".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath);
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    );
     assert!(matches!(result, Err(Error::InvalidName(_))));
 }
 
@@ -239,7 +252,11 @@ fn create_req_missing_space_should_fail() {
 
     let tmp_dir = tempfile::tempdir().unwrap();
     let tmp_space_abspath = tmp_dir.path();
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, tmp_space_abspath);
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        tmp_space_abspath,
+    );
     assert!(matches!(result, Err(Error::Io(_))));
 }
 
@@ -255,11 +272,18 @@ fn create_req_sanitizes_filename() {
         fsname: "special-chars-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request with special characters");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request with special characters");
 
     let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("special-chars-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -282,11 +306,18 @@ fn create_req_with_unicode_characters() {
         fsname: "ザク-unicode-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request with unicode characters");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request with unicode characters");
 
     let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("ザク-unicode-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -309,11 +340,18 @@ fn create_req_with_whitespace_handling() {
         fsname: "multiple-spaces-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request with whitespace");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request with whitespace");
 
     let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("multiple-spaces-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -333,10 +371,18 @@ fn create_req_duplicate_name_should_fail() {
         fsname: "duplicate-req-1".to_string(),
     };
 
-    request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create first request");
+    request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create first request");
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath);
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    );
 
     assert!(result.is_err());
 }
@@ -624,7 +670,7 @@ fn http_req_from_reqtoml_parses_url_correctly() {
         },
     };
 
-    let http_req = HttpReq::from_reqtoml(&req_toml, "url-parse-req-1.toml".to_string());
+    let http_req = HttpReq::from_reqtoml(&req_toml, &PathBuf::from("url-parse-req-1.toml"));
 
     assert_eq!(
         http_req.config.url.raw,
@@ -654,7 +700,7 @@ fn http_req_from_reqtoml_handles_invalid_url() {
         },
     };
 
-    let http_req = HttpReq::from_reqtoml(&req_toml, "invalid-url-req-1.toml".to_string());
+    let http_req = HttpReq::from_reqtoml(&req_toml, &PathBuf::from("invalid-url-req-1.toml"));
 
     assert_eq!(http_req.config.url.raw, Some("not-a-valid-url".to_string()));
     assert!(http_req.config.url.protocol.is_none());
@@ -669,6 +715,7 @@ fn http_req_from_reqbuf_has_unsaved_changes() {
             fsname: "buffer-req-1.toml".to_string(),
             name: "Buffer Req 1".to_string(),
             has_unsaved_changes: true,
+            relpath: PathBuf::from("buffer-req-1.toml"),
         },
         config: ReqCfg {
             method: "POST".to_string(),
@@ -697,11 +744,13 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Req 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Great Grand Parent Col 1")
+            .join("Grand Parent Col 1")
+            .join("Parent Col 1")
+            .join("Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -713,7 +762,10 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
         .join("grand-parent-col-1")
         .join("parent-col-1")
         .join("child-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     assert!(tmp_space_abspath.join("great-grand-parent-col-1").exists());
     assert!(tmp_space_abspath
@@ -744,12 +796,19 @@ fn create_req_handles_mixed_invalid_characters_and_unicode() {
         fsname: "ザク-special-chars-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request with mixed characters");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request with mixed characters");
 
     let expected_reqfile_relpath =
         PathBuf::from("parent-col-1").join("ザク-special-chars-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -765,11 +824,12 @@ fn create_req_with_trailing_slash_in_relpath() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/Child Col 1/Trailing Req 1/";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Trailing Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -780,7 +840,10 @@ fn create_req_with_trailing_slash_in_relpath() {
     let expected_reqfile_relpath = PathBuf::from("parent-col-1")
         .join("child-col-1")
         .join("trailing-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 }
 
 #[test]
@@ -795,8 +858,12 @@ fn create_req_updates_shared_state() {
         fsname: "state-update-req-1".to_string(),
     };
 
-    request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request");
+    request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request");
 
     assert!(tmp_space_abspath
         .join("parent-col-1")
@@ -816,11 +883,18 @@ fn create_req_with_backslash_characters() {
         fsname: "back-slash-req-1".to_string(),
     };
 
-    let result = request::create_req(Path::new("parent-col-1"), &req_segment, &tmp_space_abspath)
-        .expect("Failed to create request with backslash");
+    let result = request::create_req(
+        &PathBuf::from("parent-col-1"),
+        &req_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create request with backslash");
 
     let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("back-slash-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     let expected_reqfile_abspath = tmp_space_abspath
         .join("parent-col-1")
@@ -836,11 +910,12 @@ fn create_req_with_multiple_slashes_in_relpath() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1///Child Col 1//Multiple Slash Req 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Multiple Slash Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -851,7 +926,10 @@ fn create_req_with_multiple_slashes_in_relpath() {
     let expected_reqfile_relpath = PathBuf::from("parent-col-1")
         .join("child-col-1")
         .join("multiple-slash-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 }
 
 #[test]
@@ -859,11 +937,12 @@ fn create_req_integrated_flow() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/Child Col 1/Grand Child Req 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Grand Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -874,7 +953,10 @@ fn create_req_integrated_flow() {
     let expected_reqfile_relpath = PathBuf::from("parent-col-1")
         .join("child-col-1")
         .join("grand-child-req-1.toml");
-    assert_eq!(result.relpath, expected_reqfile_relpath.to_string_lossy());
+    assert_eq!(
+        result.relpath.to_string_lossy().to_string(),
+        expected_reqfile_relpath.to_string_lossy().to_string()
+    );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
     assert!(tmp_space_abspath

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -743,10 +743,7 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Great Grand Parent Col 1")
-            .join("Grand Parent Col 1")
-            .join("Parent Col 1")
-            .join("Child Req 1"),
+        &PathBuf::from("Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -170,10 +170,9 @@ fn create_req_basic() {
     )
     .expect("Failed to create request");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("child-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("child-req-1.toml")
     );
 
     let expected_reqfile_abspath = tmp_space_abspath
@@ -194,9 +193,7 @@ fn create_req_with_nested_collections() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Grand Parent Col 1")
-            .join("Parent Col 1")
-            .join("Child Req 1"),
+        &PathBuf::from("Grand Parent Col 1/Parent Col 1/Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -204,20 +201,19 @@ fn create_req_with_nested_collections() {
     let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with nested collections");
 
-    let expected_reqfile_relpath = PathBuf::from("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-req-1.toml")
     );
-
-    let expected_reqfile_abspath = tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-req-1.toml");
-    assert!(expected_reqfile_abspath.exists());
-
+    assert!(
+        tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-req-1.toml")
+            .exists()
+    );
     assert!(tmp_space_abspath.join("grand-parent-col-1").exists());
     assert!(
         tmp_space_abspath
@@ -281,10 +277,9 @@ fn create_req_sanitizes_filename() {
     )
     .expect("Failed to create request with special characters");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("special-chars-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("special-chars-req-1.toml")
     );
 
     let expected_reqfile_abspath = tmp_space_abspath
@@ -315,10 +310,9 @@ fn create_req_with_unicode_characters() {
     )
     .expect("Failed to create request with unicode characters");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("ザク-unicode-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("ザク-unicode-req-1.toml")
     );
 
     let expected_reqfile_abspath = tmp_space_abspath
@@ -349,16 +343,16 @@ fn create_req_with_whitespace_handling() {
     )
     .expect("Failed to create request with whitespace");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("multiple-spaces-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1").join("multiple-spaces-req-1.toml")
     );
-
-    let expected_reqfile_abspath = tmp_space_abspath
-        .join("parent-col-1")
-        .join("multiple-spaces-req-1.toml");
-    assert!(expected_reqfile_abspath.exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("multiple-spaces-req-1.toml")
+            .exists()
+    );
 }
 
 #[test]
@@ -760,13 +754,12 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
     let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with deep hierarchy");
 
-    let expected_reqfile_relpath = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-req-1.toml")
     );
 
     assert!(tmp_space_abspath.join("great-grand-parent-col-1").exists());
@@ -811,11 +804,9 @@ fn create_req_handles_mixed_invalid_characters_and_unicode() {
     )
     .expect("Failed to create request with mixed characters");
 
-    let expected_reqfile_relpath =
-        PathBuf::from("parent-col-1").join("ザク-special-chars-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1/ザク-special-chars-req-1.toml")
     );
 
     let expected_reqfile_abspath = tmp_space_abspath
@@ -835,9 +826,7 @@ fn create_req_with_trailing_slash_in_relpath() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Trailing Req 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Trailing Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -845,12 +834,11 @@ fn create_req_with_trailing_slash_in_relpath() {
     let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with trailing slash");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1")
-        .join("child-col-1")
-        .join("trailing-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1")
+            .join("child-col-1")
+            .join("trailing-req-1.toml")
     );
 }
 
@@ -900,10 +888,9 @@ fn create_req_with_backslash_characters() {
     )
     .expect("Failed to create request with backslash");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1").join("back-slash-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1/back-slash-req-1.toml")
     );
 
     let expected_reqfile_abspath = tmp_space_abspath
@@ -923,9 +910,7 @@ fn create_req_with_multiple_slashes_in_relpath() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Multiple Slash Req 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Multiple Slash Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -933,12 +918,11 @@ fn create_req_with_multiple_slashes_in_relpath() {
     let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request with multiple slashes");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1")
-        .join("child-col-1")
-        .join("multiple-slash-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1")
+            .join("child-col-1")
+            .join("multiple-slash-req-1.toml")
     );
 }
 
@@ -950,9 +934,7 @@ fn create_req_integrated_flow() {
     let location_relpath = PathBuf::from("");
     let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Grand Child Req 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Req 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -960,12 +942,11 @@ fn create_req_integrated_flow() {
     let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let expected_reqfile_relpath = PathBuf::from("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-req-1.toml");
     assert_eq!(
-        result.relpath.to_string_lossy().to_string(),
-        expected_reqfile_relpath.to_string_lossy().to_string()
+        result.relpath,
+        PathBuf::from("parent-col-1")
+            .join("child-col-1")
+            .join("grand-child-req-1.toml")
     );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
@@ -983,10 +964,7 @@ fn create_req_integrated_flow() {
             .exists()
     );
 
-    let req_toml_path = tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-req-1.toml");
+    let req_toml_path = tmp_space_abspath.join("parent-col-1/child-col-1/grand-child-req-1.toml");
     let req_toml = request::parse_reqtoml(&req_toml_path).unwrap();
     assert_eq!(req_toml.meta.name, "Grand Child Req 1");
 }

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -8,7 +8,7 @@ use crate::{
         self,
         models::{HttpReq, ReqCfg, ReqMeta, ReqToml, ReqTomlConfig, ReqTomlMeta, ReqUrl},
     },
-    store::{self, spaces::buffer::SpaceBufferStore, ReqBuffer},
+    store::{self, ReqBuffer, spaces::buffer::SpaceBufferStore},
 };
 
 #[test]
@@ -219,10 +219,12 @@ fn create_req_with_nested_collections() {
     assert!(expected_reqfile_abspath.exists());
 
     assert!(tmp_space_abspath.join("grand-parent-col-1").exists());
-    assert!(tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -768,21 +770,27 @@ fn create_req_creates_parent_collections_with_proper_hierarchy() {
     );
 
     assert!(tmp_space_abspath.join("great-grand-parent-col-1").exists());
-    assert!(tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .exists());
-    assert!(tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .exists());
-    assert!(tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-req-1.toml")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .exists()
+    );
+    assert!(
+        tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .exists()
+    );
+    assert!(
+        tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-req-1.toml")
+            .exists()
+    );
 }
 
 #[test]
@@ -865,10 +873,12 @@ fn create_req_updates_shared_state() {
     )
     .expect("Failed to create request");
 
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("state-update-req-1.toml")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("state-update-req-1.toml")
+            .exists()
+    );
 }
 
 #[test]
@@ -959,15 +969,19 @@ fn create_req_integrated_flow() {
     );
 
     assert!(tmp_space_abspath.join("parent-col-1").exists());
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
-    assert!(tmp_space_abspath
-        .join("parent-col-1")
-        .join("child-col-1")
-        .join("grand-child-req-1.toml")
-        .exists());
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
+    assert!(
+        tmp_space_abspath
+            .join("parent-col-1")
+            .join("child-col-1")
+            .join("grand-child-req-1.toml")
+            .exists()
+    );
 
     let req_toml_path = tmp_space_abspath
         .join("parent-col-1")

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -224,6 +224,33 @@ fn create_req_with_nested_collections() {
 }
 
 #[test]
+fn create_req_with_nested_collections_and_backslash() {
+    let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
+    let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
+
+    let location_relpath = PathBuf::from("");
+    let (parent_relpath, req_segment) = collection::create_parent_collections_if_missing(
+        &location_relpath,
+        &PathBuf::from("Grand Parent Col 1\\Parent Col 1\\Child Req 1"),
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create parent collections");
+
+    let result = request::create_req(&parent_relpath, &req_segment, &tmp_space_abspath)
+        .expect("Failed to create request with nested collections");
+
+    assert_eq!(
+        result.relpath,
+        PathBuf::from("grand-parent-col-1-parent-col-1-child-req-1.toml")
+    );
+    assert!(
+        tmp_space_abspath
+            .join("grand-parent-col-1-parent-col-1-child-req-1.toml")
+            .exists()
+    );
+}
+
+#[test]
 fn create_req_empty_fsname_should_fail() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Req Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::Write,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use crate::{
@@ -18,16 +18,15 @@ use crate::{
 pub mod models;
 
 pub fn create_space(dto: CreateSpaceDto, state_store: &mut StateStore) -> Result<SpaceReference> {
-    let location = PathBuf::from(dto.location.as_str());
-    if !location.exists() {
+    if !dto.location.exists() {
         return Err(Error::FileNotFound(format!(
             "Location does not exist: {}",
-            dto.location
+            dto.location.display()
         )));
     }
 
     let space_dirname = utils::to_fsname(&dto.name)?;
-    let space_abspath = location.join(&space_dirname);
+    let space_abspath = dto.location.join(&space_dirname);
     if space_abspath.exists() {
         return Err(Error::FileConflict(format!(
             "Directory with this name already exists: {}",
@@ -60,7 +59,7 @@ pub fn create_space(dto: CreateSpaceDto, state_store: &mut StateStore) -> Result
     config_file.write_all(toml::to_string_pretty(&config)?.as_bytes())?;
 
     let spaceref = SpaceReference {
-        abspath: space_abspath.to_path_buf(),
+        abspath: space_abspath,
         name: dto.name,
     };
 
@@ -73,7 +72,6 @@ pub fn create_space(dto: CreateSpaceDto, state_store: &mut StateStore) -> Result
 }
 
 pub fn parse_space(space_abspath: &Path, state_store: &StateStore) -> Result<Space> {
-    let space_abspath_str = space_abspath.to_string_lossy();
     let root_collection = collection::parse_root_collection(space_abspath, state_store)?;
     let space_config_file = parse_spacecfg(space_abspath)?;
 
@@ -96,7 +94,7 @@ pub fn parse_space(space_abspath: &Path, state_store: &StateStore) -> Result<Spa
     let space_settings = SpaceSettingsStore::get(&sst_store_abspath)?.into_inner();
 
     Ok(Space {
-        abspath: space_abspath_str.into_owned(),
+        abspath: space_abspath.to_path_buf(),
         meta: space_config_file.meta,
         root_collection,
         cookies: cookies_by_domain,
@@ -105,7 +103,7 @@ pub fn parse_space(space_abspath: &Path, state_store: &StateStore) -> Result<Spa
 }
 
 pub fn parse_spacecfg(space_abspath: &Path) -> Result<SpaceConfigFile> {
-    let path = space_abspath.join(".zaku/config.toml");
+    let path = space_abspath.join(".zaku").join("config.toml");
     let content =
         fs::read_to_string(&path).map_err(|_| Error::FileNotFound(path.display().to_string()))?;
     let config = toml::from_str(&content)
@@ -118,9 +116,7 @@ pub fn first_valid_spaceref(state_store: &StateStore) -> Option<SpaceReference> 
     let spacerefs = state_store.spacerefs.clone();
 
     spacerefs.into_iter().find_map(|space_reference| {
-        let space_abspath = &space_reference.abspath;
-
-        match parse_spacecfg(space_abspath) {
+        match parse_spacecfg(&space_reference.abspath) {
             Ok(_) => Some(space_reference),
             Err(_) => None,
         }

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -25,7 +25,7 @@ pub fn create_space(dto: CreateSpaceDto, state_store: &mut StateStore) -> Result
         )));
     }
 
-    let space_dirname = utils::to_fsname(&dto.name)?;
+    let space_dirname = utils::to_sanitized_fsname(&dto.name)?;
     let space_abspath = dto.location.join(&space_dirname);
     if space_abspath.exists() {
         return Err(Error::FileConflict(format!(

--- a/src-tauri/src/space/models.rs
+++ b/src-tauri/src/space/models.rs
@@ -8,7 +8,7 @@ use crate::{collection::models::Collection, store::SpaceSettings};
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct CreateSpaceDto {
     pub name: String,
-    pub location: String,
+    pub location: PathBuf,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
@@ -23,7 +23,7 @@ pub struct SpaceConfigFile {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct Space {
-    pub abspath: String,
+    pub abspath: PathBuf,
     pub meta: SpaceMeta,
     pub root_collection: Collection,
     pub cookies: HashMap<String, Vec<SerializedCookie>>,

--- a/src-tauri/src/store/spaces/buffer.rs
+++ b/src-tauri/src/store/spaces/buffer.rs
@@ -17,7 +17,7 @@ static SBF_STORE_UPDATE_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
 pub struct SpaceBuffer {
-    pub requests: HashMap<String, ReqBuffer>,
+    pub requests: HashMap<PathBuf, ReqBuffer>,
 }
 
 #[derive(Debug, Clone)]
@@ -41,18 +41,18 @@ impl DerefMut for SpaceBufferStore {
 }
 
 impl SpaceBufferStore {
-    fn new(sbf_store_abspath: PathBuf) -> Self {
+    fn new(sbf_store_abspath: &Path) -> Self {
         Self {
             buffer: SpaceBuffer {
-                requests: HashMap::new(),
+                requests: HashMap::<PathBuf, ReqBuffer>::new(),
             },
-            abspath: sbf_store_abspath,
+            abspath: sbf_store_abspath.to_path_buf(),
         }
     }
 
     fn init(sbf_store_abspath: &Path) -> Result<Arc<Mutex<SpaceBufferStore>>> {
         if !sbf_store_abspath.exists() {
-            let default_buffer = Arc::new(Mutex::new(Self::new(sbf_store_abspath.to_path_buf())));
+            let default_buffer = Arc::new(Mutex::new(Self::new(sbf_store_abspath)));
             Self::fswrite(&default_buffer)?;
 
             return Ok(default_buffer);
@@ -68,7 +68,7 @@ impl SpaceBufferStore {
             },
             Err(_) => {
                 // corrupt JSON, use default
-                let default_buffer = Self::new(sbf_store_abspath.to_path_buf());
+                let default_buffer = Self::new(sbf_store_abspath);
                 let buffer_arc = Arc::new(Mutex::new(default_buffer));
                 Self::fswrite(&buffer_arc)?;
 
@@ -130,6 +130,7 @@ impl ReqBuffer {
             fsname: req.meta.fsname.clone(),
             name: req.meta.name.clone(),
             has_unsaved_changes: true,
+            relpath: req.meta.relpath.clone(),
         };
 
         let config = ReqCfg {

--- a/src-tauri/src/store/spaces/cookie.rs
+++ b/src-tauri/src/store/spaces/cookie.rs
@@ -15,17 +15,17 @@ pub struct SpaceCookieStore {
 }
 
 impl SpaceCookieStore {
-    fn new(sck_store_abspath: PathBuf, cookies: Arc<CookieStoreMutex>) -> Self {
+    fn new(sck_store_abspath: &Path, cookies: Arc<CookieStoreMutex>) -> Self {
         Self {
             cookies,
-            abspath: sck_store_abspath,
+            abspath: sck_store_abspath.to_path_buf(),
         }
     }
 
     fn init(sck_store_abspath: &Path) -> Result<SpaceCookieStore> {
         if !sck_store_abspath.exists() {
             let default_cookies = Arc::new(CookieStoreMutex::new(CookieStore::default()));
-            let sck_store = Self::new(sck_store_abspath.to_path_buf(), default_cookies);
+            let sck_store = Self::new(sck_store_abspath, default_cookies);
             sck_store.fswrite()?;
 
             return Ok(sck_store);
@@ -37,12 +37,12 @@ impl SpaceCookieStore {
             Ok(cookie_store) => {
                 let cookies = Arc::new(CookieStoreMutex::new(cookie_store));
 
-                Ok(Self::new(sck_store_abspath.to_path_buf(), cookies))
+                Ok(Self::new(sck_store_abspath, cookies))
             }
             Err(_) => {
                 // corrupt JSON, use default
                 let default_cookies = Arc::new(CookieStoreMutex::new(CookieStore::default()));
-                let sck_store = Self::new(sck_store_abspath.to_path_buf(), default_cookies);
+                let sck_store = Self::new(sck_store_abspath, default_cookies);
                 sck_store.fswrite()?;
 
                 Ok(sck_store)

--- a/src-tauri/src/store/spaces/settings.rs
+++ b/src-tauri/src/store/spaces/settings.rs
@@ -42,7 +42,7 @@ impl Deref for SpaceSettingsStore {
 }
 
 impl SpaceSettingsStore {
-    fn new(sst_store_abspath: PathBuf) -> Self {
+    fn new(sst_store_abspath: &Path) -> Self {
         let datadir_abspath = sst_store_abspath
             .parent()
             .and_then(|p| p.parent())
@@ -61,13 +61,13 @@ impl SpaceSettingsStore {
                     },
                 },
             },
-            abspath: sst_store_abspath,
+            abspath: sst_store_abspath.to_path_buf(),
         }
     }
 
     fn init(sst_store_abspath: &Path) -> Result<Self> {
         if !sst_store_abspath.exists() {
-            let sst_store = Self::new(sst_store_abspath.to_path_buf());
+            let sst_store = Self::new(sst_store_abspath);
             sst_store.fswrite()?;
 
             return Ok(sst_store);
@@ -82,7 +82,7 @@ impl SpaceSettingsStore {
             }),
             Err(_) => {
                 // corrupt JSON, use default
-                let sst_store = Self::new(sst_store_abspath.to_path_buf());
+                let sst_store = Self::new(sst_store_abspath);
                 sst_store.fswrite()?;
 
                 Ok(sst_store)

--- a/src-tauri/src/store/spaces/settings.rs
+++ b/src-tauri/src/store/spaces/settings.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     error::Result,
-    store::{self, state::Theme, StateStore},
+    store::{self, StateStore, state::Theme},
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]

--- a/src-tauri/src/store/state.rs
+++ b/src-tauri/src/store/state.rs
@@ -70,7 +70,7 @@ impl Deref for StateStore {
 }
 
 impl StateStore {
-    pub fn new(state_store_abspath: PathBuf) -> Self {
+    pub fn new(state_store_abspath: &Path) -> Self {
         Self {
             state: State {
                 spaceref: None,
@@ -79,13 +79,13 @@ impl StateStore {
                     default_theme: Theme::System,
                 },
             },
-            abspath: state_store_abspath,
+            abspath: state_store_abspath.to_path_buf(),
         }
     }
 
     fn init(state_store_abspath: &Path) -> Result<StateStore> {
         if !state_store_abspath.exists() {
-            let default_store = Self::new(state_store_abspath.to_path_buf());
+            let default_store = Self::new(state_store_abspath);
             default_store.fswrite()?;
 
             return Ok(default_store);
@@ -100,7 +100,7 @@ impl StateStore {
             }),
             Err(_) => {
                 // corrupt JSON, use default
-                let default_store = Self::new(state_store_abspath.to_path_buf());
+                let default_store = Self::new(state_store_abspath);
                 default_store.fswrite()?;
 
                 Ok(default_store)

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -31,18 +31,21 @@ fn state_store_get_loads_existing_store_from_filesystem() {
         fs::create_dir_all(parent).unwrap();
     }
 
+    let test_space_1_path = PathBuf::from("test").join("space-1");
+    let test_space_2_path = PathBuf::from("test").join("space-2");
+
     let json_content = serde_json::json!({
         "spaceref": {
-            "abspath": "/test/space-1",
+            "abspath": test_space_1_path,
             "name": "Test Space 1"
         },
         "spacerefs": [
             {
-                "abspath": "/test/space-1",
+                "abspath": test_space_1_path,
                 "name": "Test Space 1"
             },
             {
-                "abspath": "/test/space-2",
+                "abspath": test_space_2_path,
                 "name": "Test Space 2"
             }
         ],
@@ -57,7 +60,7 @@ fn state_store_get_loads_existing_store_from_filesystem() {
     assert!(loaded_state_store.spaceref.is_some());
     assert_eq!(
         loaded_state_store.spaceref.as_ref().unwrap().abspath,
-        PathBuf::from("/test/space-1")
+        test_space_1_path
     );
     assert_eq!(loaded_state_store.spacerefs.len(), 2);
     assert_eq!(loaded_state_store.spacerefs[0].name, "Test Space 1");
@@ -70,11 +73,11 @@ fn state_store_update_persists_changes_to_filesystem() {
     let store_abspath = store::utils::state_store_abspath(tmp_dir.path());
 
     let space_ref_1 = SpaceReference {
-        abspath: PathBuf::from("/test/space-1"),
+        abspath: PathBuf::from("test").join("space-1"),
         name: "Test Space 1".to_string(),
     };
     let space_ref_2 = SpaceReference {
-        abspath: PathBuf::from("/test/space-2"),
+        abspath: PathBuf::from("test").join("space-2"),
         name: "Test Space 2".to_string(),
     };
 
@@ -95,7 +98,7 @@ fn state_store_update_persists_changes_to_filesystem() {
     assert!(fresh_state_store.spaceref.is_some());
     assert_eq!(
         fresh_state_store.spaceref.as_ref().unwrap().abspath,
-        PathBuf::from("/test/space-1")
+        PathBuf::from("test").join("space-1")
     );
     assert_eq!(fresh_state_store.user_settings.default_theme, Theme::Light);
     assert_eq!(fresh_state_store.spacerefs.len(), 2);
@@ -189,6 +192,7 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
             fsname: "test-req.toml".to_string(),
             name: "Test Req".to_string(),
             has_unsaved_changes: true,
+            relpath: PathBuf::from("test-req.toml"),
         },
         config: ReqCfg {
             method: "GET".to_string(),
@@ -210,18 +214,22 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
         let mut sbf_store_mtx = sbf_store.lock().unwrap();
         sbf_store_mtx
             .requests
-            .insert("test-req.toml".to_string(), req_buf);
+            .insert(PathBuf::from("test-req.toml"), req_buf);
     })
     .unwrap();
 
     assert!(sbf_store_abspath.exists());
 
     let sbf_store_mtx = sbf_store.lock().unwrap();
-    assert!(sbf_store_mtx.requests.contains_key("test-req.toml"));
+    assert!(sbf_store_mtx
+        .requests
+        .contains_key(&PathBuf::from("test-req.toml")));
 
     let fresh_sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let fresh_lock = fresh_sbf_store.lock().unwrap();
-    assert!(fresh_lock.requests.contains_key("test-req.toml"));
+    assert!(fresh_lock
+        .requests
+        .contains_key(&PathBuf::from("test-req.toml")));
 }
 
 #[test]
@@ -237,15 +245,16 @@ fn sbf_store_handles_concurrent_access_to_same_buffer_instance() {
     let handles: Vec<_> = (0..10)
         .map(|idx| {
             let sbf_store = Arc::clone(&sbf_store);
-            let key = format!("concurrent-req-{idx}.toml");
+            let req_fsname = format!("concurrent-req-{idx}.toml");
 
             thread::spawn(move || {
                 let mut sbf_store_mtx = sbf_store.lock().unwrap();
                 let req_buf = ReqBuffer {
                     meta: ReqMeta {
-                        fsname: key.clone(),
+                        fsname: req_fsname.clone(),
                         name: format!("Concurrent Req {idx}"),
                         has_unsaved_changes: false,
+                        relpath: PathBuf::from(req_fsname.clone()),
                     },
                     config: ReqCfg {
                         method: "GET".to_string(),
@@ -261,7 +270,9 @@ fn sbf_store_handles_concurrent_access_to_same_buffer_instance() {
                         body: None,
                     },
                 };
-                sbf_store_mtx.requests.insert(key, req_buf);
+                sbf_store_mtx
+                    .requests
+                    .insert(PathBuf::from(req_fsname), req_buf);
             })
         })
         .collect();
@@ -274,8 +285,8 @@ fn sbf_store_handles_concurrent_access_to_same_buffer_instance() {
     assert_eq!(sbf_store_mtx.requests.len(), 10);
 
     for idx in 0..10 {
-        let key = format!("concurrent-req-{idx}.toml");
-        assert!(sbf_store_mtx.requests.contains_key(&key));
+        let req_relpath = PathBuf::from(format!("concurrent-req-{idx}.toml"));
+        assert!(sbf_store_mtx.requests.contains_key(&req_relpath));
     }
 }
 
@@ -291,6 +302,7 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
             fsname: "persistent-req.toml".to_string(),
             name: "Persistent Req".to_string(),
             has_unsaved_changes: false,
+            relpath: PathBuf::from("persistent-req.toml"),
         },
         config: ReqCfg {
             method: "POST".to_string(),
@@ -312,15 +324,20 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
         let mut sbf_store_mtx = sbf_store.lock().unwrap();
         sbf_store_mtx
             .requests
-            .insert("persistent-req.toml".to_string(), req_buf);
+            .insert(PathBuf::from("persistent-req.toml"), req_buf);
     })
     .unwrap();
 
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store.lock().unwrap();
-    assert!(sbf_store_mtx.requests.contains_key("persistent-req.toml"));
+    assert!(sbf_store_mtx
+        .requests
+        .contains_key(&PathBuf::from("persistent-req.toml")));
 
-    let persisted_req = sbf_store_mtx.requests.get("persistent-req.toml").unwrap();
+    let persisted_req = sbf_store_mtx
+        .requests
+        .get(&PathBuf::from("persistent-req.toml"))
+        .unwrap();
     assert_eq!(persisted_req.meta.name, "Persistent Req");
     assert_eq!(persisted_req.config.method, "POST");
 }
@@ -344,6 +361,7 @@ fn sbf_store_serializes_concurrent_update_calls_without_data_loss() {
                         fsname: format!("update-req-{idx}.toml"),
                         name: format!("Update Req {idx}"),
                         has_unsaved_changes: true,
+                        relpath: PathBuf::from(format!("update-req-{idx}.toml")),
                     },
                     config: ReqCfg {
                         method: "PUT".to_string(),
@@ -362,8 +380,8 @@ fn sbf_store_serializes_concurrent_update_calls_without_data_loss() {
 
                 SpaceBufferStore::update(&sbf_store, |sbf_store| {
                     let mut sbf_store_mtx = sbf_store.lock().unwrap();
-                    let key = format!("update-req-{idx}.toml");
-                    sbf_store_mtx.requests.insert(key, req_buf);
+                    let req_relpath = PathBuf::from(format!("update-req-{idx}.toml"));
+                    sbf_store_mtx.requests.insert(req_relpath, req_buf);
                 })
                 .unwrap();
             })
@@ -378,10 +396,10 @@ fn sbf_store_serializes_concurrent_update_calls_without_data_loss() {
     assert_eq!(sbf_store_mtx.requests.len(), 10);
 
     for idx in 0..10 {
-        let key = format!("update-req-{idx}.toml");
-        assert!(sbf_store_mtx.requests.contains_key(&key));
+        let req_relpath = PathBuf::from(format!("update-req-{idx}.toml"));
+        assert!(sbf_store_mtx.requests.contains_key(&req_relpath));
 
-        let req = sbf_store_mtx.requests.get(&key).unwrap();
+        let req = sbf_store_mtx.requests.get(&req_relpath).unwrap();
         assert_eq!(req.meta.name, format!("Update Req {idx}"));
         assert_eq!(req.config.method, "PUT");
         assert!(req.meta.has_unsaved_changes);

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -6,7 +6,7 @@ use crate::store::{self, StateStore};
 use crate::{
     request::models::{ReqCfg, ReqMeta, ReqUrl},
     space::models::SpaceReference,
-    store::{state::Theme, ReqBuffer, SpaceBufferStore},
+    store::{ReqBuffer, SpaceBufferStore, state::Theme},
 };
 
 #[test]
@@ -221,15 +221,19 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
     assert!(sbf_store_abspath.exists());
 
     let sbf_store_mtx = sbf_store.lock().unwrap();
-    assert!(sbf_store_mtx
-        .requests
-        .contains_key(&PathBuf::from("test-req.toml")));
+    assert!(
+        sbf_store_mtx
+            .requests
+            .contains_key(&PathBuf::from("test-req.toml"))
+    );
 
     let fresh_sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let fresh_lock = fresh_sbf_store.lock().unwrap();
-    assert!(fresh_lock
-        .requests
-        .contains_key(&PathBuf::from("test-req.toml")));
+    assert!(
+        fresh_lock
+            .requests
+            .contains_key(&PathBuf::from("test-req.toml"))
+    );
 }
 
 #[test]
@@ -330,9 +334,11 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
 
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store.lock().unwrap();
-    assert!(sbf_store_mtx
-        .requests
-        .contains_key(&PathBuf::from("persistent-req.toml")));
+    assert!(
+        sbf_store_mtx
+            .requests
+            .contains_key(&PathBuf::from("persistent-req.toml"))
+    );
 
     let persisted_req = sbf_store_mtx
         .requests

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -73,11 +73,11 @@ fn state_store_update_persists_changes_to_filesystem() {
     let store_abspath = store::utils::state_store_abspath(tmp_dir.path());
 
     let space_ref_1 = SpaceReference {
-        abspath: PathBuf::from("test").join("space-1"),
+        abspath: PathBuf::from("test/space-1"),
         name: "Test Space 1".to_string(),
     };
     let space_ref_2 = SpaceReference {
-        abspath: PathBuf::from("test").join("space-2"),
+        abspath: PathBuf::from("test/space-2"),
         name: "Test Space 2".to_string(),
     };
 

--- a/src-tauri/src/store/utils.rs
+++ b/src-tauri/src/store/utils.rs
@@ -60,7 +60,7 @@ pub fn temp_space(space_name: &str) -> (tempfile::TempDir, tempfile::TempDir, St
     let state_store_abspath = state_store_abspath(tmp_datadir.path());
     let dto = CreateSpaceDto {
         name: space_name.to_string(),
-        location: tmp_spacedir.path().to_string_lossy().to_string(),
+        location: tmp_spacedir.path().to_path_buf(),
     };
     let mut state_store =
         StateStore::get(&state_store_abspath).expect("Failed to init state store");

--- a/src-tauri/src/tree_node/mod.rs
+++ b/src-tauri/src/tree_node/mod.rs
@@ -34,8 +34,8 @@ impl fmt::Display for NodeType {
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct MoveTreeNodeDto {
     pub node_type: NodeType,
-    pub from_relpath: PathBuf,
-    pub to_relpath: PathBuf,
+    pub cur_relpath: PathBuf,
+    pub nxt_relpath: PathBuf,
 }
 
 /// Finds a collection within the collection tree by traversing the relative path
@@ -72,35 +72,35 @@ pub fn find_collection<'a>(root: &'a Collection, relpath: &Path) -> Result<&'a C
 /// directories exists before moving. Throws an error if any of these conditions
 /// are not met.
 ///
-/// - `src_abspath`: Absolute path of the source file/directory
-/// - `dest_abspath`: Absolute path of the destination file/directory
+/// - `cur_abspath`: Absolute path of the source file/directory
+/// - `nxt_abspath`: Absolute path of the destination file/directory
 ///
 /// Returns a `Result` indicating success or failure of the move operation
-fn fsmove(src_abspath: &Path, dest_abspath: &Path) -> Result<()> {
-    if !src_abspath.exists() {
+fn fsmove(cur_abspath: &Path, nxt_abspath: &Path) -> Result<()> {
+    if !cur_abspath.exists() {
         return Err(Error::FileNotFound(format!(
             "Source does not exist: {}",
-            src_abspath.display()
+            cur_abspath.display()
         )));
     }
 
-    if dest_abspath.exists() {
+    if nxt_abspath.exists() {
         return Err(Error::InvalidPath(format!(
             "Destination already exists: {}",
-            dest_abspath.display()
+            nxt_abspath.display()
         )));
     }
 
-    if let Some(dest_dir) = dest_abspath.parent() {
-        if !dest_dir.exists() {
+    if let Some(nxt_dir) = nxt_abspath.parent() {
+        if !nxt_dir.exists() {
             return Err(Error::InvalidPath(format!(
                 "Destination parent directory does not exist: {}",
-                dest_dir.display()
+                nxt_dir.display()
             )));
         }
     }
 
-    fs::rename(src_abspath, dest_abspath)?;
+    fs::rename(cur_abspath, nxt_abspath)?;
 
     Ok(())
 }
@@ -110,18 +110,18 @@ fn fsmove(src_abspath: &Path, dest_abspath: &Path) -> Result<()> {
 /// Searches through the appropriate collection (collections or requests) based
 /// on the node type to determine if a node with the same filesystem name exists.
 ///
-/// - `dest_parent_col`: Collection to check for existing nodes
+/// - `nxt_parent_col`: Collection to check for existing nodes
 /// - `node_type`: Type of node to check for (Collection or Request)
 /// - `fsname`: Filesystem name to search for
 ///
 /// Returns `true` if a node with the same name exists, `false` otherwise
-fn node_exists_at_dest(dest_parent_col: &Collection, node_type: &NodeType, fsname: &str) -> bool {
+fn node_exists_at_dest(nxt_parent_col: &Collection, node_type: &NodeType, fsname: &str) -> bool {
     match node_type {
-        NodeType::Collection => dest_parent_col
+        NodeType::Collection => nxt_parent_col
             .collections
             .iter()
             .any(|c| c.meta.fsname == fsname),
-        NodeType::Request => dest_parent_col
+        NodeType::Request => nxt_parent_col
             .requests
             .iter()
             .any(|r| r.meta.fsname == fsname),
@@ -133,18 +133,18 @@ fn node_exists_at_dest(dest_parent_col: &Collection, node_type: &NodeType, fsnam
 /// Verifies that the node being moved actually exists in the source collection
 /// before attempting the move operation.
 ///
-/// - `src_parent_col`: Collection to check for the source node
+/// - `cur_parent_col`: Collection to check for the source node
 /// - `node_type`: Type of node to check for (Collection or Request)
 /// - `fsname`: Filesystem name to search for
 ///
 /// Returns `true` if the source node exists, `false` otherwise
-fn src_exists(src_parent_col: &Collection, node_type: &NodeType, fsname: &str) -> bool {
+fn cur_exists(cur_parent_col: &Collection, node_type: &NodeType, fsname: &str) -> bool {
     match node_type {
-        NodeType::Collection => src_parent_col
+        NodeType::Collection => cur_parent_col
             .collections
             .iter()
             .any(|c| c.meta.fsname == fsname),
-        NodeType::Request => src_parent_col
+        NodeType::Request => cur_parent_col
             .requests
             .iter()
             .any(|r| r.meta.fsname == fsname),
@@ -173,55 +173,55 @@ pub fn move_tree_node(
 ) -> Result<()> {
     let space = space::parse_space(space_abspath, state_store)?;
 
-    let src_fsname = dto
-        .from_relpath
+    let cur_fsname = dto
+        .cur_relpath
         .file_name()
         .ok_or_else(|| Error::InvalidPath("Invalid source path".to_string()))?
         .to_string_lossy()
         .to_string();
 
-    let src_parent_relpath = dto.from_relpath.parent().unwrap_or_else(|| Path::new(""));
-    let dest_parent_relpath = dto.to_relpath.parent().unwrap_or_else(|| Path::new(""));
+    let cur_parent_relpath = dto.cur_relpath.parent().unwrap_or_else(|| Path::new(""));
+    let nxt_parent_relpath = dto.nxt_relpath.parent().unwrap_or_else(|| Path::new(""));
 
-    if src_parent_relpath == dest_parent_relpath {
+    if cur_parent_relpath == nxt_parent_relpath {
         return Err(Error::InvalidPath("Cannot drop to same parent".into()));
     }
 
     if dto.node_type == NodeType::Collection {
-        let collection_path = src_parent_relpath.join(&src_fsname);
-        if dest_parent_relpath.starts_with(&collection_path) {
+        let collection_path = cur_parent_relpath.join(&cur_fsname);
+        if nxt_parent_relpath.starts_with(&collection_path) {
             return Err(Error::InvalidPath(
                 "Cannot move collection into itself".into(),
             ));
         }
     }
 
-    let dest_parent_col = find_collection(&space.root_collection, dest_parent_relpath)?;
-    if node_exists_at_dest(dest_parent_col, &dto.node_type, &src_fsname) {
+    let nxt_parent_col = find_collection(&space.root_collection, nxt_parent_relpath)?;
+    if node_exists_at_dest(nxt_parent_col, &dto.node_type, &cur_fsname) {
         return Err(Error::InvalidPath(format!(
             "{} '{}' already exists",
-            dto.node_type, src_fsname
+            dto.node_type, cur_fsname
         )));
     }
 
-    let src_parent_col = find_collection(&space.root_collection, src_parent_relpath)?;
-    if !src_exists(src_parent_col, &dto.node_type, &src_fsname) {
+    let cur_parent_col = find_collection(&space.root_collection, cur_parent_relpath)?;
+    if !cur_exists(cur_parent_col, &dto.node_type, &cur_fsname) {
         return Err(Error::InvalidPath(format!(
             "{} '{}' not found",
-            dto.node_type, src_fsname
+            dto.node_type, cur_fsname
         )));
     }
 
-    let src_abspath = space_abspath.join(&dto.from_relpath);
-    let dest_abspath = space_abspath.join(&dto.to_relpath);
+    let cur_abspath = space_abspath.join(&dto.cur_relpath);
+    let nxt_abspath = space_abspath.join(&dto.nxt_relpath);
 
-    fsmove(&src_abspath, &dest_abspath)?;
+    fsmove(&cur_abspath, &nxt_abspath)?;
 
     if dto.node_type == NodeType::Collection {
         let mut scmt_store = SpaceCollectionsMetadataStore::get(space_abspath)?;
         scmt_store.update(|metadata| {
-            if let Some(name) = metadata.mappings.remove(&dto.from_relpath) {
-                metadata.mappings.insert(dto.to_relpath.clone(), name);
+            if let Some(name) = metadata.mappings.remove(&dto.cur_relpath) {
+                metadata.mappings.insert(dto.nxt_relpath.clone(), name);
             }
         })?;
     }

--- a/src-tauri/src/tree_node/mod.rs
+++ b/src-tauri/src/tree_node/mod.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::{
     fmt, fs,
-    path::{self, Path},
+    path::{self, Path, PathBuf},
 };
 
 use crate::{
@@ -34,8 +34,8 @@ impl fmt::Display for NodeType {
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct MoveTreeNodeDto {
     pub node_type: NodeType,
-    pub src_relpath: String,
-    pub dest_relpath: String,
+    pub from_relpath: PathBuf,
+    pub to_relpath: PathBuf,
 }
 
 /// Finds a collection within the collection tree by traversing the relative path
@@ -173,18 +173,15 @@ pub fn move_tree_node(
 ) -> Result<()> {
     let space = space::parse_space(space_abspath, state_store)?;
 
-    let src_fsname = Path::new(&dto.src_relpath)
+    let src_fsname = dto
+        .from_relpath
         .file_name()
         .ok_or_else(|| Error::InvalidPath("Invalid source path".to_string()))?
         .to_string_lossy()
         .to_string();
 
-    let src_parent_relpath = Path::new(&dto.src_relpath)
-        .parent()
-        .unwrap_or_else(|| Path::new(""));
-    let dest_parent_relpath = Path::new(&dto.dest_relpath)
-        .parent()
-        .unwrap_or_else(|| Path::new(""));
+    let src_parent_relpath = dto.from_relpath.parent().unwrap_or_else(|| Path::new(""));
+    let dest_parent_relpath = dto.to_relpath.parent().unwrap_or_else(|| Path::new(""));
 
     if src_parent_relpath == dest_parent_relpath {
         return Err(Error::InvalidPath("Cannot drop to same parent".into()));
@@ -215,16 +212,16 @@ pub fn move_tree_node(
         )));
     }
 
-    let src_abspath = space_abspath.join(&dto.src_relpath);
-    let dest_abspath = space_abspath.join(&dto.dest_relpath);
+    let src_abspath = space_abspath.join(&dto.from_relpath);
+    let dest_abspath = space_abspath.join(&dto.to_relpath);
 
     fsmove(&src_abspath, &dest_abspath)?;
 
     if dto.node_type == NodeType::Collection {
         let mut scmt_store = SpaceCollectionsMetadataStore::get(space_abspath)?;
         scmt_store.update(|metadata| {
-            if let Some(name) = metadata.mappings.remove(&dto.src_relpath) {
-                metadata.mappings.insert(dto.dest_relpath.clone(), name);
+            if let Some(name) = metadata.mappings.remove(&dto.from_relpath) {
+                metadata.mappings.insert(dto.to_relpath.clone(), name);
             }
         })?;
     }

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -390,10 +390,12 @@ fn move_tree_node_successfully_moves_collection() {
     assert_eq!(moved_collection.meta.fsname, "parent-col-1");
 
     assert!(!&tmp_space_abspath.join("parent-col-1").exists());
-    assert!(&tmp_space_abspath
-        .join("parent-col-2")
-        .join("parent-col-1")
-        .exists());
+    assert!(
+        &tmp_space_abspath
+            .join("parent-col-2")
+            .join("parent-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -442,10 +444,12 @@ fn move_tree_node_successfully_moves_request() {
     assert_eq!(moved_request.meta.fsname, "parent-req-1.toml");
 
     assert!(!&tmp_space_abspath.join("parent-req-1.toml").exists());
-    assert!(&tmp_space_abspath
-        .join("parent-col-1")
-        .join("parent-req-1.toml")
-        .exists());
+    assert!(
+        &tmp_space_abspath
+            .join("parent-col-1")
+            .join("parent-req-1.toml")
+            .exists()
+    );
 }
 
 #[test]
@@ -541,20 +545,26 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
 
     let parent_path = PathBuf::from("grand-parent-col-1").join("parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
-    assert!(!parent_col
-        .collections
-        .iter()
-        .any(|c| c.meta.fsname == "child-col-1"));
+    assert!(
+        !parent_col
+            .collections
+            .iter()
+            .any(|c| c.meta.fsname == "child-col-1")
+    );
 
-    assert!(!&tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
-    assert!(&tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("child-col-1")
-        .exists());
+    assert!(
+        !&tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
+    assert!(
+        &tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -609,20 +619,26 @@ fn move_tree_node_successfully_moves_request_to_parent() {
 
     let parent_path = PathBuf::from("grand-parent-col-1").join("parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
-    assert!(!parent_col
-        .requests
-        .iter()
-        .any(|r| r.meta.fsname == "grand-child-req-1.toml"));
+    assert!(
+        !parent_col
+            .requests
+            .iter()
+            .any(|r| r.meta.fsname == "grand-child-req-1.toml")
+    );
 
-    assert!(!&tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("grand-child-req-1.toml")
-        .exists());
-    assert!(&tmp_space_abspath
-        .join("grand-parent-col-1")
-        .join("grand-child-req-1.toml")
-        .exists());
+    assert!(
+        !&tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("grand-child-req-1.toml")
+            .exists()
+    );
+    assert!(
+        &tmp_space_abspath
+            .join("grand-parent-col-1")
+            .join("grand-child-req-1.toml")
+            .exists()
+    );
 }
 
 #[test]
@@ -673,22 +689,28 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
         .join("grand-parent-col-1")
         .join("parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
-    assert!(!parent_col
-        .collections
-        .iter()
-        .any(|c| c.meta.fsname == "child-col-1"));
+    assert!(
+        !parent_col
+            .collections
+            .iter()
+            .any(|c| c.meta.fsname == "child-col-1")
+    );
 
-    assert!(!&tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-col-1")
-        .exists());
-    assert!(&tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("child-col-1")
-        .exists());
+    assert!(
+        !&tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
+    assert!(
+        &tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("child-col-1")
+            .exists()
+    );
 }
 
 #[test]
@@ -748,19 +770,25 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
         .join("grand-parent-col-1")
         .join("parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
-    assert!(!parent_col
-        .requests
-        .iter()
-        .any(|r| r.meta.fsname == "great-grand-child-req-1.toml"));
+    assert!(
+        !parent_col
+            .requests
+            .iter()
+            .any(|r| r.meta.fsname == "great-grand-child-req-1.toml")
+    );
 
-    assert!(!&tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("great-grand-child-req-1.toml")
-        .exists());
-    assert!(&tmp_space_abspath
-        .join("great-grand-parent-col-1")
-        .join("great-grand-child-req-1.toml")
-        .exists());
+    assert!(
+        !&tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("grand-parent-col-1")
+            .join("parent-col-1")
+            .join("great-grand-child-req-1.toml")
+            .exists()
+    );
+    assert!(
+        &tmp_space_abspath
+            .join("great-grand-parent-col-1")
+            .join("great-grand-child-req-1.toml")
+            .exists()
+    );
 }

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 
 use crate::{
     collection,
@@ -17,7 +14,7 @@ fn find_collection_returns_root_for_empty_path() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
 
-    let result = tree_node::find_collection(&space, Path::new(""));
+    let result = tree_node::find_collection(&space, &PathBuf::from(""));
     assert!(result.is_ok());
     assert_eq!(result.unwrap().meta.fsname, "tree-space".to_string());
 }
@@ -27,11 +24,10 @@ fn find_collection_finds_direct_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -40,7 +36,7 @@ fn find_collection_finds_direct_child() {
         .expect("Failed to create collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let result = tree_node::find_collection(&space, Path::new("parent-col-1"));
+    let result = tree_node::find_collection(&space, &PathBuf::from("parent-col-1"));
     assert!(result.is_ok());
     let collection = result.unwrap();
     assert_eq!(collection.meta.name, Some("Parent Col 1".to_string()));
@@ -52,11 +48,10 @@ fn find_collection_finds_nested_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1/Child Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1").join("Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -79,7 +74,7 @@ fn find_collection_fails_for_nonexistent_path() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
 
-    let result = tree_node::find_collection(&space, Path::new("nonexistent-col-1"));
+    let result = tree_node::find_collection(&space, &PathBuf::from("nonexistent-col-1"));
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => {
@@ -94,11 +89,10 @@ fn find_collection_fails_for_partially_invalid_path() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -123,11 +117,11 @@ fn move_tree_node_fails_with_no_space() {
     let (_tmp_datadir, tmp_spacedir, state_store) = store::utils::temp_space("Test Space");
     let tmp_nonexistent_space_abspath = tmp_spacedir.path().join("nonexistent");
 
-    let dest_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
+    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath, &state_store);
@@ -139,15 +133,15 @@ fn move_tree_node_fails_with_no_space() {
 }
 
 #[test]
-fn move_tree_node_fails_with_invalid_src_relpath() {
+fn move_tree_node_fails_with_invalid_from_relpath() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let dest_relpath = PathBuf::from("parent-col-1").join("child-col-1");
+    let to_relpath = PathBuf::from("parent-col-1").join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from(""),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -163,11 +157,10 @@ fn move_tree_node_fails_when_dropping_to_same_parent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -177,8 +170,8 @@ fn move_tree_node_fails_when_dropping_to_same_parent() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: "parent-col-2".to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-2"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -194,11 +187,10 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
-    let relpath = "Parent Col 1";
+    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -206,11 +198,11 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let dest_relpath = PathBuf::from("parent-col-1").join("parent-col-1");
+    let to_relpath = PathBuf::from("parent-col-1").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -226,11 +218,11 @@ fn move_tree_node_fails_when_destination_already_exists() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -238,11 +230,11 @@ fn move_tree_node_fails_when_destination_already_exists() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -256,17 +248,17 @@ fn move_tree_node_fails_when_destination_already_exists() {
     };
 
     collection::create_collection(
-        Path::new("parent-col-2"),
+        &PathBuf::from("parent-col-2"),
         &conflicting_segment,
         &tmp_space_abspath,
     )
     .expect("Failed to create conflicting collection");
 
-    let dest_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
+    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -282,11 +274,11 @@ fn move_tree_node_fails_when_source_not_found() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -294,11 +286,11 @@ fn move_tree_node_fails_when_source_not_found() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let dest_relpath = PathBuf::from("parent-col-1").join("nonexistent-col-1");
+    let to_relpath = PathBuf::from("parent-col-1").join("nonexistent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "nonexistent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("nonexistent-col-1"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -314,11 +306,11 @@ fn move_tree_node_successfully_moves_collection() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -326,11 +318,11 @@ fn move_tree_node_successfully_moves_collection() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -338,18 +330,17 @@ fn move_tree_node_successfully_moves_collection() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let dest_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-2").join("parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
     assert!(result.is_ok());
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let parent_col = tree_node::find_collection(&space, Path::new("parent-col-2")).unwrap();
+    let parent_col = tree_node::find_collection(&space, &PathBuf::from("parent-col-2")).unwrap();
     let moved_collection = parent_col
         .collections
         .iter()
@@ -375,14 +366,14 @@ fn move_tree_node_successfully_moves_request() {
         fsname: "parent-req-1".to_string(),
     };
 
-    request::create_req(Path::new(""), &req_segment, &tmp_space_abspath)
+    request::create_req(&PathBuf::from(""), &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -390,18 +381,18 @@ fn move_tree_node_successfully_moves_request() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let dest_relpath = PathBuf::from("parent-col-1").join("parent-req-1.toml");
+    let to_relpath = PathBuf::from("parent-col-1").join("parent-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        src_relpath: "parent-req-1.toml".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-req-1.toml"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
     assert!(result.is_ok());
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let parent_col = tree_node::find_collection(&space, Path::new("parent-col-1")).unwrap();
+    let parent_col = tree_node::find_collection(&space, &PathBuf::from("parent-col-1")).unwrap();
     let moved_request = parent_col
         .requests
         .iter()
@@ -422,11 +413,11 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -434,11 +425,11 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -450,11 +441,11 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     fs::remove_dir_all(tmp_space_abspath.join("parent-col-2"))
         .expect("Failed to remove parent directory");
 
-    let dest_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
+    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: "parent-col-1".to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -472,11 +463,11 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Grand Parent Col 1/Parent Col 1/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -484,14 +475,14 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
-    let src_relpath = PathBuf::from("grand-parent-col-1")
+    let from_relpath = PathBuf::from("grand-parent-col-1")
         .join("parent-col-1")
         .join("child-col-1");
-    let dest_relpath = PathBuf::from("grand-parent-col-1").join("child-col-1");
+    let to_relpath = PathBuf::from("grand-parent-col-1").join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: src_relpath.to_string_lossy().to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: from_relpath,
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -499,7 +490,7 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
     let grandparent_col =
-        tree_node::find_collection(&space, Path::new("grand-parent-col-1")).unwrap();
+        tree_node::find_collection(&space, &PathBuf::from("grand-parent-col-1")).unwrap();
     let moved_collection = grandparent_col
         .collections
         .iter()
@@ -531,11 +522,11 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Grand Parent Col 1/Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -552,14 +543,14 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     request::create_req(&req_parent_path, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let src_relpath = PathBuf::from("grand-parent-col-1")
+    let from_relpath = PathBuf::from("grand-parent-col-1")
         .join("parent-col-1")
         .join("grand-child-req-1.toml");
-    let dest_relpath = PathBuf::from("grand-parent-col-1").join("grand-child-req-1.toml");
+    let to_relpath = PathBuf::from("grand-parent-col-1").join("grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        src_relpath: src_relpath.to_string_lossy().to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: from_relpath,
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -567,7 +558,7 @@ fn move_tree_node_successfully_moves_request_to_parent() {
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
     let grandparent_col =
-        tree_node::find_collection(&space, Path::new("grand-parent-col-1")).unwrap();
+        tree_node::find_collection(&space, &PathBuf::from("grand-parent-col-1")).unwrap();
     let moved_request = grandparent_col
         .requests
         .iter()
@@ -599,11 +590,11 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -611,17 +602,17 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create deeply nested collection");
 
-    let src_relpath = PathBuf::from("great-grand-parent-col-1")
+    let from_relpath = PathBuf::from("great-grand-parent-col-1")
         .join("grand-parent-col-1")
         .join("parent-col-1")
         .join("child-col-1");
-    let dest_relpath = PathBuf::from("great-grand-parent-col-1")
+    let to_relpath = PathBuf::from("great-grand-parent-col-1")
         .join("grand-parent-col-1")
         .join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        src_relpath: src_relpath.to_string_lossy().to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: from_relpath,
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -665,11 +656,11 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = Path::new("");
+    let location_relpath = PathBuf::from("");
     let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        location_relpath,
-        relpath,
+        &location_relpath,
+        &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -688,16 +679,15 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     request::create_req(&req_parent_path, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let src_relpath = PathBuf::from("great-grand-parent-col-1")
+    let from_relpath = PathBuf::from("great-grand-parent-col-1")
         .join("grand-parent-col-1")
         .join("parent-col-1")
         .join("great-grand-child-req-1.toml");
-    let dest_relpath =
-        PathBuf::from("great-grand-parent-col-1").join("great-grand-child-req-1.toml");
+    let to_relpath = PathBuf::from("great-grand-parent-col-1").join("great-grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        src_relpath: src_relpath.to_string_lossy().to_string(),
-        dest_relpath: dest_relpath.to_string_lossy().to_string(),
+        from_relpath: from_relpath,
+        to_relpath: to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -705,7 +695,7 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
     let great_grandparent_col =
-        tree_node::find_collection(&space, Path::new("great-grand-parent-col-1")).unwrap();
+        tree_node::find_collection(&space, &PathBuf::from("great-grand-parent-col-1")).unwrap();
     let moved_request = great_grandparent_col
         .requests
         .iter()

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -153,7 +153,7 @@ fn move_tree_node_fails_with_invalid_from_relpath() {
 }
 
 #[test]
-fn move_tree_node_fails_when_dropping_to_same_parent() {
+fn move_tree_node_fails_when_moving_to_self() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
@@ -171,15 +171,53 @@ fn move_tree_node_fails_when_dropping_to_same_parent() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2"),
+        to_relpath: PathBuf::from("parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
     assert!(result.is_err());
-    match result.unwrap_err() {
-        Error::InvalidPath(msg) => assert_eq!(msg, "Cannot drop to same parent"),
-        _ => panic!("Expected InvalidPath error"),
-    }
+}
+
+#[test]
+fn move_tree_node_fails_when_moving_into_own_subtree() {
+    let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
+    let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
+
+    let location_relpath = PathBuf::from("");
+    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+        &location_relpath,
+        &PathBuf::from("Parent Col 1"),
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create parent collections");
+
+    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+        .expect("Failed to create collection");
+
+    let child_location = PathBuf::from("parent-col-1");
+    let (child_parent_relpath, child_col_segment) =
+        collection::create_parent_collections_if_missing(
+            &child_location,
+            &PathBuf::from("Child Col"),
+            &tmp_space_abspath,
+        )
+        .expect("Failed to create child collections");
+
+    collection::create_collection(
+        &child_parent_relpath,
+        &child_col_segment,
+        &tmp_space_abspath,
+    )
+    .expect("Failed to create child collection");
+
+    let dto = MoveTreeNodeDto {
+        node_type: NodeType::Collection,
+        from_relpath: PathBuf::from("parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
+    };
+
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -719,10 +719,9 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let location_relpath = PathBuf::from("");
-    let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &location_relpath,
-        &PathBuf::from(relpath),
+        &PathBuf::from("Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -24,14 +24,14 @@ fn find_collection_finds_direct_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
@@ -47,14 +47,14 @@ fn find_collection_finds_nested_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1/Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
@@ -87,14 +87,14 @@ fn find_collection_fails_for_partially_invalid_path() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
@@ -116,8 +116,8 @@ fn move_tree_node_fails_with_no_space() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath, &state_store);
@@ -129,14 +129,14 @@ fn move_tree_node_fails_with_no_space() {
 }
 
 #[test]
-fn move_tree_node_fails_with_invalid_from_relpath() {
+fn move_tree_node_fails_with_invalid_cur_relpath() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from(""),
-        to_relpath: PathBuf::from("parent-col-1/child-col-1"),
+        cur_relpath: PathBuf::from(""),
+        nxt_relpath: PathBuf::from("parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -152,20 +152,20 @@ fn move_tree_node_fails_when_moving_to_self() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -177,18 +177,18 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
     let child_location = PathBuf::from("parent-col-1");
-    let (child_parent_relpath, child_col_segment) =
+    let (child_location_relpath, child_col_segment) =
         collection::create_parent_collections_if_missing(
             &child_location,
             &PathBuf::from("Child Col"),
@@ -197,7 +197,7 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
         .expect("Failed to create child collections");
 
     collection::create_collection(
-        &child_parent_relpath,
+        &child_location_relpath,
         &child_col_segment,
         &tmp_space_abspath,
     )
@@ -205,8 +205,8 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -218,20 +218,20 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-1/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -248,25 +248,25 @@ fn move_tree_node_fails_when_destination_already_exists() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
     let relpath = "Parent Col 2/Child Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create existing collection");
 
     let conflicting_segment = SanitizedSegment {
@@ -283,8 +283,8 @@ fn move_tree_node_fails_when_destination_already_exists() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -301,20 +301,20 @@ fn move_tree_node_fails_when_source_not_found() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("nonexistent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1/nonexistent-col-1"),
+        cur_relpath: PathBuf::from("nonexistent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-1/nonexistent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -331,31 +331,31 @@ fn move_tree_node_successfully_moves_collection() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
     let relpath = "Parent Col 2";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -394,20 +394,20 @@ fn move_tree_node_successfully_moves_request() {
         .expect("Failed to create request");
 
     let relpath = "Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath: PathBuf::from("parent-req-1.toml"),
-        to_relpath: PathBuf::from("parent-col-1/parent-req-1.toml"),
+        cur_relpath: PathBuf::from("parent-req-1.toml"),
+        nxt_relpath: PathBuf::from("parent-col-1/parent-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -438,25 +438,25 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
     let relpath = "Parent Col 2";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
     let _space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
@@ -465,8 +465,8 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
+        cur_relpath: PathBuf::from("parent-col-1"),
+        nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -485,20 +485,20 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Grand Parent Col 1/Parent Col 1/Child Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/child-col-1"),
-        to_relpath: PathBuf::from("grand-parent-col-1/child-col-1"),
+        cur_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/child-col-1"),
+        nxt_relpath: PathBuf::from("grand-parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -545,14 +545,14 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Grand Parent Col 1/Parent Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
     let req_segment = SanitizedSegment {
@@ -566,8 +566,8 @@ fn move_tree_node_successfully_moves_request_to_parent() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/grand-child-req-1.toml"),
-        to_relpath: PathBuf::from("grand-parent-col-1/grand-child-req-1.toml"),
+        cur_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/grand-child-req-1.toml"),
+        nxt_relpath: PathBuf::from("grand-parent-col-1/grand-child-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -614,22 +614,22 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
     let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Col 1";
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create deeply nested collection");
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: PathBuf::from(
+        cur_relpath: PathBuf::from(
             "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/child-col-1",
         ),
-        to_relpath: PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1"),
+        nxt_relpath: PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -677,14 +677,14 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
+    let (location_relpath, col_segment) = collection::create_parent_collections_if_missing(
         &PathBuf::from(""),
         &PathBuf::from("Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
 
-    collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
+    collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
     let req_segment = SanitizedSegment {
@@ -698,10 +698,10 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
 
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath: PathBuf::from(
+        cur_relpath: PathBuf::from(
             "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/great-grand-child-req-1.toml",
         ),
-        to_relpath: PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml"),
+        nxt_relpath: PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -658,13 +658,9 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create deeply nested collection");
 
-    let from_relpath = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-col-1");
-    let to_relpath = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("child-col-1");
+    let from_relpath =
+        PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/parent-col-1/child-col-1");
+    let to_relpath = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath,
@@ -685,9 +681,7 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     assert_eq!(moved_collection.meta.name, Some("Child Col 1".to_string()));
     assert_eq!(moved_collection.meta.fsname, "child-col-1");
 
-    let parent_path = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1");
+    let parent_path = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
     assert!(
         !parent_col
@@ -734,17 +728,14 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
         fsname: "great-grand-child-req-1".to_string(),
     };
 
-    let req_parent_path = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1");
+    let req_parent_path = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/parent-col-1");
     request::create_req(&req_parent_path, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let from_relpath = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("great-grand-child-req-1.toml");
-    let to_relpath = PathBuf::from("great-grand-parent-col-1").join("great-grand-child-req-1.toml");
+    let from_relpath = PathBuf::from(
+        "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/great-grand-child-req-1.toml",
+    );
+    let to_relpath = PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
         from_relpath,

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -121,7 +121,7 @@ fn move_tree_node_fails_with_no_space() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath, &state_store);
@@ -141,7 +141,7 @@ fn move_tree_node_fails_with_invalid_from_relpath() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from(""),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -202,7 +202,7 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -258,7 +258,7 @@ fn move_tree_node_fails_when_destination_already_exists() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -290,7 +290,7 @@ fn move_tree_node_fails_when_source_not_found() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("nonexistent-col-1"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -385,7 +385,7 @@ fn move_tree_node_successfully_moves_request() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
         from_relpath: PathBuf::from("parent-req-1.toml"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -445,7 +445,7 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: to_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -481,8 +481,8 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     let to_relpath = PathBuf::from("grand-parent-col-1").join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: from_relpath,
-        to_relpath: to_relpath,
+        from_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -549,8 +549,8 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     let to_relpath = PathBuf::from("grand-parent-col-1").join("grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath: from_relpath,
-        to_relpath: to_relpath,
+        from_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -611,8 +611,8 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
         .join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath: from_relpath,
-        to_relpath: to_relpath,
+        from_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -686,8 +686,8 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     let to_relpath = PathBuf::from("great-grand-parent-col-1").join("great-grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath: from_relpath,
-        to_relpath: to_relpath,
+        from_relpath,
+        to_relpath,
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -213,7 +213,9 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-1")
+            .join("child-col")
+            .join("parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -24,9 +24,8 @@ fn find_collection_finds_direct_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -48,10 +47,9 @@ fn find_collection_finds_nested_child() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
-        &PathBuf::from("Parent Col 1").join("Child Col 1"),
+        &PathBuf::from(""),
+        &PathBuf::from("Parent Col 1/Child Col 1"),
         &tmp_space_abspath,
     )
     .expect("Failed to create parent collections");
@@ -60,7 +58,7 @@ fn find_collection_finds_nested_child() {
         .expect("Failed to create nested collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let nested_path = PathBuf::from("parent-col-1").join("child-col-1");
+    let nested_path = PathBuf::from("parent-col-1/child-col-1");
     let result = tree_node::find_collection(&space, &nested_path);
     assert!(result.is_ok());
     let collection = result.unwrap();
@@ -89,9 +87,8 @@ fn find_collection_fails_for_partially_invalid_path() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -101,7 +98,7 @@ fn find_collection_fails_for_partially_invalid_path() {
         .expect("Failed to create parent collection");
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let invalid_path = PathBuf::from("parent-col-1").join("missing-child-col-1");
+    let invalid_path = PathBuf::from("parent-col-1/missing-child-col-1");
     let result = tree_node::find_collection(&space, &invalid_path);
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -117,11 +114,10 @@ fn move_tree_node_fails_with_no_space() {
     let (_tmp_datadir, tmp_spacedir, state_store) = store::utils::temp_space("Test Space");
     let tmp_nonexistent_space_abspath = tmp_spacedir.path().join("nonexistent");
 
-    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath, &state_store);
@@ -137,11 +133,10 @@ fn move_tree_node_fails_with_invalid_from_relpath() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let to_relpath = PathBuf::from("parent-col-1").join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from(""),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -157,9 +152,8 @@ fn move_tree_node_fails_when_moving_to_self() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -183,9 +177,8 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -213,9 +206,7 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-1")
-            .join("child-col")
-            .join("parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -227,9 +218,8 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -238,11 +228,10 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let to_relpath = PathBuf::from("parent-col-1").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-1/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -258,10 +247,9 @@ fn move_tree_node_fails_when_destination_already_exists() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -270,10 +258,9 @@ fn move_tree_node_fails_when_destination_already_exists() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -294,11 +281,10 @@ fn move_tree_node_fails_when_destination_already_exists() {
     )
     .expect("Failed to create conflicting collection");
 
-    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -314,10 +300,9 @@ fn move_tree_node_fails_when_source_not_found() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -326,11 +311,10 @@ fn move_tree_node_fails_when_source_not_found() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let to_relpath = PathBuf::from("parent-col-1").join("nonexistent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("nonexistent-col-1"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-1/nonexistent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -346,10 +330,9 @@ fn move_tree_node_successfully_moves_collection() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -358,10 +341,9 @@ fn move_tree_node_successfully_moves_collection() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -373,7 +355,7 @@ fn move_tree_node_successfully_moves_collection() {
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath: PathBuf::from("parent-col-2").join("parent-col-1"),
+        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -411,10 +393,9 @@ fn move_tree_node_successfully_moves_request() {
     request::create_req(&PathBuf::from(""), &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -423,11 +404,10 @@ fn move_tree_node_successfully_moves_request() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let to_relpath = PathBuf::from("parent-col-1").join("parent-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
         from_relpath: PathBuf::from("parent-req-1.toml"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-1/parent-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -457,10 +437,9 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -469,10 +448,9 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create source collection");
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Parent Col 2";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -485,11 +463,10 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     fs::remove_dir_all(tmp_space_abspath.join("parent-col-2"))
         .expect("Failed to remove parent directory");
 
-    let to_relpath = PathBuf::from("parent-col-2").join("parent-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
         from_relpath: PathBuf::from("parent-col-1"),
-        to_relpath,
+        to_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -507,10 +484,9 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Grand Parent Col 1/Parent Col 1/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -519,14 +495,10 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
-    let from_relpath = PathBuf::from("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("child-col-1");
-    let to_relpath = PathBuf::from("grand-parent-col-1").join("child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath,
-        to_relpath,
+        from_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/child-col-1"),
+        to_relpath: PathBuf::from("grand-parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -543,7 +515,7 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
     assert_eq!(moved_collection.meta.name, Some("Child Col 1".to_string()));
     assert_eq!(moved_collection.meta.fsname, "child-col-1");
 
-    let parent_path = PathBuf::from("grand-parent-col-1").join("parent-col-1");
+    let parent_path = PathBuf::from("grand-parent-col-1/parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
     assert!(
         !parent_col
@@ -572,10 +544,9 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Grand Parent Col 1/Parent Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -589,18 +560,14 @@ fn move_tree_node_successfully_moves_request_to_parent() {
         fsname: "grand-child-req-1".to_string(),
     };
 
-    let req_parent_path = PathBuf::from("grand-parent-col-1").join("parent-col-1");
+    let req_parent_path = PathBuf::from("grand-parent-col-1/parent-col-1");
     request::create_req(&req_parent_path, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let from_relpath = PathBuf::from("grand-parent-col-1")
-        .join("parent-col-1")
-        .join("grand-child-req-1.toml");
-    let to_relpath = PathBuf::from("grand-parent-col-1").join("grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath,
-        to_relpath,
+        from_relpath: PathBuf::from("grand-parent-col-1/parent-col-1/grand-child-req-1.toml"),
+        to_relpath: PathBuf::from("grand-parent-col-1/grand-child-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -617,7 +584,7 @@ fn move_tree_node_successfully_moves_request_to_parent() {
     assert_eq!(moved_request.meta.name, "Grand Child Req 1");
     assert_eq!(moved_request.meta.fsname, "grand-child-req-1.toml");
 
-    let parent_path = PathBuf::from("grand-parent-col-1").join("parent-col-1");
+    let parent_path = PathBuf::from("grand-parent-col-1/parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
     assert!(
         !parent_col
@@ -646,10 +613,9 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let relpath = "Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1/Child Col 1";
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from(relpath),
         &tmp_space_abspath,
     )
@@ -658,20 +624,19 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
     collection::create_collection(&parent_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create deeply nested collection");
 
-    let from_relpath =
-        PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/parent-col-1/child-col-1");
-    let to_relpath = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Collection,
-        from_relpath,
-        to_relpath,
+        from_relpath: PathBuf::from(
+            "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/child-col-1",
+        ),
+        to_relpath: PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
     assert!(result.is_ok());
 
     let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
-    let grandparent_path = PathBuf::from("great-grand-parent-col-1").join("grand-parent-col-1");
+    let grandparent_path = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1");
     let grandparent_col = tree_node::find_collection(&space, &grandparent_path).unwrap();
     let moved_collection = grandparent_col
         .collections
@@ -712,9 +677,8 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
 
-    let location_relpath = PathBuf::from("");
     let (parent_relpath, col_segment) = collection::create_parent_collections_if_missing(
-        &location_relpath,
+        &PathBuf::from(""),
         &PathBuf::from("Great Grand Parent Col 1/Grand Parent Col 1/Parent Col 1"),
         &tmp_space_abspath,
     )
@@ -732,14 +696,12 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     request::create_req(&req_parent_path, &req_segment, &tmp_space_abspath)
         .expect("Failed to create request");
 
-    let from_relpath = PathBuf::from(
-        "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/great-grand-child-req-1.toml",
-    );
-    let to_relpath = PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml");
     let dto = MoveTreeNodeDto {
         node_type: NodeType::Request,
-        from_relpath,
-        to_relpath,
+        from_relpath: PathBuf::from(
+            "great-grand-parent-col-1/grand-parent-col-1/parent-col-1/great-grand-child-req-1.toml",
+        ),
+        to_relpath: PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml"),
     };
 
     let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
@@ -756,9 +718,7 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
     assert_eq!(moved_request.meta.name, "Great Grand Child Req 1");
     assert_eq!(moved_request.meta.fsname, "great-grand-child-req-1.toml");
 
-    let parent_path = PathBuf::from("great-grand-parent-col-1")
-        .join("grand-parent-col-1")
-        .join("parent-col-1");
+    let parent_path = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/parent-col-1");
     let parent_col = tree_node::find_collection(&space, &parent_path).unwrap();
     assert!(
         !parent_col

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -105,11 +105,12 @@ pub fn to_fsname(name: &str) -> Result<String> {
     Ok(sanitized)
 }
 
-pub fn to_sanitized_segments(relpath: &str) -> Result<Vec<SanitizedSegment>> {
-    let relpath_no_bslashes = relpath.replace('\\', "-");
+pub fn to_sanitized_segments(relpath: &Path) -> Result<Vec<SanitizedSegment>> {
+    let relpath_str = relpath.to_string_lossy();
+    let relpath_no_bslashes = relpath_str.replace('\\', "-");
     let mut segments = Vec::new();
 
-    for component in Path::new(&relpath_no_bslashes).components() {
+    for component in PathBuf::from(&relpath_no_bslashes).components() {
         if let path::Component::Normal(os_str) = component {
             let name = os_str.to_string_lossy().trim().to_string();
             if !name.is_empty() {

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -68,13 +68,13 @@ pub fn hashed_filename(abspath: &Path) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-pub fn to_fsname(name: &str) -> Result<String> {
+pub fn to_sanitized_fsname(name: &str) -> Result<String> {
     const WINDOWS_RESERVED: [&str; 22] = [
         "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
         "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
     ];
 
-    let sanitized = name
+    let sanitized_fsname = name
         .to_lowercase()
         .chars()
         .map(|char| {
@@ -90,19 +90,38 @@ pub fn to_fsname(name: &str) -> Result<String> {
         .collect::<Vec<_>>()
         .join("-");
 
-    if sanitized.is_empty() {
+    if sanitized_fsname.is_empty() {
         return Err(Error::SanitizationError(
             "Empty name after sanitization".to_string(),
         ));
     }
 
-    if WINDOWS_RESERVED.contains(&sanitized.as_str()) {
+    if WINDOWS_RESERVED.contains(&sanitized_fsname.as_str()) {
         return Err(Error::SanitizationError(format!(
-            "Reserved name not allowed: {sanitized}"
+            "Reserved name not allowed: {sanitized_fsname}"
         )));
     }
 
-    Ok(sanitized)
+    Ok(sanitized_fsname)
+}
+
+pub fn to_sanitized_name(name: &str) -> Result<String> {
+    let sanitized_name = name
+        .trim_matches(|char| char == '-' || char == ' ')
+        .chars()
+        .fold(String::new(), |mut acc, char| {
+            match (char, acc.chars().last()) {
+                ('-', Some('-')) => acc,
+                (' ', Some(' ')) => acc,
+                _ => {
+                    acc.push(char);
+
+                    acc
+                }
+            }
+        });
+
+    Ok(sanitized_name)
 }
 
 pub fn to_sanitized_segments(relpath: &Path) -> Result<Vec<SanitizedSegment>> {
@@ -112,9 +131,9 @@ pub fn to_sanitized_segments(relpath: &Path) -> Result<Vec<SanitizedSegment>> {
 
     for component in PathBuf::from(&relpath_no_bslashes).components() {
         if let path::Component::Normal(os_str) = component {
-            let name = os_str.to_string_lossy().trim().to_string();
+            let name = to_sanitized_name(&os_str.to_string_lossy())?;
             if !name.is_empty() {
-                let fsname = to_fsname(&name)?;
+                let fsname = to_sanitized_fsname(&name)?;
                 segments.push(SanitizedSegment { name, fsname });
             }
         }

--- a/src-tauri/src/utils/tests.rs
+++ b/src-tauri/src/utils/tests.rs
@@ -1,9 +1,14 @@
 use crate::{error::Error, utils};
+use std::path::PathBuf;
 
 #[test]
 fn to_sanitized_segments_basic() {
-    let segments =
-        utils::to_sanitized_segments("Parent Col 1/Child Col 1/Grand Child Col 1").unwrap();
+    let segments = utils::to_sanitized_segments(
+        &PathBuf::from("Parent Col 1")
+            .join("Child Col 1")
+            .join("Grand Child Col 1"),
+    )
+    .unwrap();
 
     assert_eq!(segments.len(), 3);
 
@@ -19,13 +24,18 @@ fn to_sanitized_segments_basic() {
 
 #[test]
 fn to_sanitized_segments_empty_relpath() {
-    let segments = utils::to_sanitized_segments("   ").unwrap();
+    let segments = utils::to_sanitized_segments(&PathBuf::from("   ")).unwrap();
     assert!(segments.is_empty());
 }
 
 #[test]
 fn to_sanitized_segments_with_whitespace_segments() {
-    let segments = utils::to_sanitized_segments("  /Whitespace Child  Col 1       /   ").unwrap();
+    let segments = utils::to_sanitized_segments(
+        &PathBuf::from("  ")
+            .join("Whitespace Child  Col 1       ")
+            .join("   "),
+    )
+    .unwrap();
 
     assert_eq!(segments.len(), 1);
 
@@ -34,28 +44,20 @@ fn to_sanitized_segments_with_whitespace_segments() {
 }
 
 #[test]
-fn to_sanitized_segments_with_multiple_slashes() {
-    let segments = utils::to_sanitized_segments("Multiple Slash Col 1///Slash  Col 1").unwrap();
-
-    assert_eq!(segments.len(), 2);
-
-    assert_eq!(segments[0].name, "Multiple Slash Col 1");
-    assert_eq!(segments[0].fsname, "multiple-slash-col-1");
-
-    assert_eq!(segments[1].name, "Slash  Col 1");
-    assert_eq!(segments[1].fsname, "slash-col-1");
-}
-
-#[test]
 fn to_sanitized_segments_with_only_empty_segments() {
-    let segments = utils::to_sanitized_segments("   /   /   ").unwrap();
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("   ").join("   ").join("   ")).unwrap();
     assert!(segments.is_empty());
 }
 
 #[test]
 fn to_sanitized_segments_special_characters() {
-    let segments =
-        utils::to_sanitized_segments("Special@Chars Col 1/Unicode# Col 2/🔥 Emoji Col 3").unwrap();
+    let segments = utils::to_sanitized_segments(
+        &PathBuf::from("Special@Chars Col 1")
+            .join("Unicode# Col 2")
+            .join("🔥 Emoji Col 3"),
+    )
+    .unwrap();
 
     assert_eq!(segments.len(), 3);
 
@@ -71,7 +73,10 @@ fn to_sanitized_segments_special_characters() {
 
 #[test]
 fn to_sanitized_segments_unicode() {
-    let segments = utils::to_sanitized_segments("ザク Unicode Col 1/設定 Unicode Col 2").unwrap();
+    let segments = utils::to_sanitized_segments(
+        &PathBuf::from("ザク Unicode Col 1").join("設定 Unicode Col 2"),
+    )
+    .unwrap();
 
     assert_eq!(segments.len(), 2);
 
@@ -83,41 +88,28 @@ fn to_sanitized_segments_unicode() {
 }
 
 #[test]
-fn to_sanitized_segments_trailing_slash() {
-    let segments =
-        utils::to_sanitized_segments("Parent Col 1/Child Trailing Slash Col 2/").unwrap();
-
-    assert_eq!(segments.len(), 2);
-
-    assert_eq!(segments[0].name, "Parent Col 1");
-    assert_eq!(segments[0].fsname, "parent-col-1");
-
-    assert_eq!(segments[1].name, "Child Trailing Slash Col 2");
-    assert_eq!(segments[1].fsname, "child-trailing-slash-col-2");
-}
-
-#[test]
 fn to_sanitized_segments_invalid_characters() {
     let segments = utils::to_sanitized_segments(
-        r#"Parent|Invalid Chars Col 1/Child Col::2"/<Grand>?Child:Invalid*Chars::\Col""3"#,
+        &PathBuf::from("Parent|Invalid")
+            .join("Child::Col")
+            .join("Grand?Child*"),
     )
     .unwrap();
 
     assert_eq!(segments.len(), 3);
+    assert_eq!(segments[0].name, "Parent|Invalid");
+    assert_eq!(segments[0].fsname, "parent-invalid");
 
-    assert_eq!(segments[0].name, "Parent|Invalid Chars Col 1");
-    assert_eq!(segments[0].fsname, "parent-invalid-chars-col-1");
+    assert_eq!(segments[1].name, "Child::Col");
+    assert_eq!(segments[1].fsname, "child-col");
 
-    assert_eq!(segments[1].name, r#"Child Col::2""#);
-    assert_eq!(segments[1].fsname, "child-col-2");
-
-    assert_eq!(segments[2].name, r#"<Grand>?Child:Invalid*Chars::-Col""3"#);
-    assert_eq!(segments[2].fsname, "grand-child-invalid-chars-col-3");
+    assert_eq!(segments[2].name, "Grand?Child*");
+    assert_eq!(segments[2].fsname, "grand-child");
 }
 
 #[test]
 fn to_sanitized_segments_reserved_names_should_be_handled() {
-    let result = utils::to_sanitized_segments("NUL/Child Col 1");
+    let result = utils::to_sanitized_segments(&PathBuf::from("NUL").join("Child Col 1"));
 
     match result {
         Err(Error::SanitizationError(msg)) => {
@@ -125,4 +117,13 @@ fn to_sanitized_segments_reserved_names_should_be_handled() {
         }
         _ => panic!("Expected SanitizationError for reserved name"),
     }
+}
+
+#[test]
+fn to_sanitized_segments_backslash() {
+    let segments = utils::to_sanitized_segments(&PathBuf::from("Path\\With\\Backslashes")).unwrap();
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].name, "Path-With-Backslashes");
+    assert_eq!(segments[0].fsname, "path-with-backslashes");
 }

--- a/src-tauri/src/utils/tests.rs
+++ b/src-tauri/src/utils/tests.rs
@@ -4,9 +4,7 @@ use std::path::PathBuf;
 #[test]
 fn to_sanitized_segments_basic() {
     let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Parent Col 1")
-            .join("Child Col 1")
-            .join("Grand Child Col 1"),
+        &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
     )
     .unwrap();
 
@@ -43,16 +41,14 @@ fn to_sanitized_segments_with_whitespace_segments() {
 #[test]
 fn to_sanitized_segments_with_only_empty_segments() {
     let segments =
-        utils::to_sanitized_segments(&PathBuf::from("   ").join("   ").join("   ")).unwrap();
+        utils::to_sanitized_segments(&PathBuf::from("   /   /   ")).unwrap();
     assert!(segments.is_empty());
 }
 
 #[test]
 fn to_sanitized_segments_special_characters() {
     let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Special@Chars Col 1")
-            .join("Unicode# Col 2")
-            .join("🔥 Emoji Col 3"),
+        &PathBuf::from("Special@Chars Col 1/Unicode# Col 2/🔥 Emoji Col 3"),
     )
     .unwrap();
 
@@ -71,7 +67,7 @@ fn to_sanitized_segments_special_characters() {
 #[test]
 fn to_sanitized_segments_unicode() {
     let segments = utils::to_sanitized_segments(
-        &PathBuf::from("ザク Unicode Col 1").join("設定 Unicode Col 2"),
+        &PathBuf::from("ザク Unicode Col 1/設定 Unicode Col 2"),
     )
     .unwrap();
 
@@ -87,9 +83,7 @@ fn to_sanitized_segments_unicode() {
 #[test]
 fn to_sanitized_segments_invalid_characters() {
     let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Parent|Invalid")
-            .join("Child::Col")
-            .join("Grand?Child*"),
+        &PathBuf::from("Parent|Invalid/Child::Col/Grand?Child*"),
     )
     .unwrap();
 
@@ -106,7 +100,7 @@ fn to_sanitized_segments_invalid_characters() {
 
 #[test]
 fn to_sanitized_segments_reserved_names_should_be_handled() {
-    let result = utils::to_sanitized_segments(&PathBuf::from("NUL").join("Child Col 1"));
+    let result = utils::to_sanitized_segments(&PathBuf::from("NUL/Child Col 1"));
 
     match result {
         Err(Error::SanitizationError(msg)) => {

--- a/src-tauri/src/utils/tests.rs
+++ b/src-tauri/src/utils/tests.rs
@@ -30,16 +30,13 @@ fn to_sanitized_segments_empty_relpath() {
 
 #[test]
 fn to_sanitized_segments_with_whitespace_segments() {
-    let segments = utils::to_sanitized_segments(
-        &PathBuf::from("  ")
-            .join("Whitespace Child  Col 1       ")
-            .join("   "),
-    )
-    .unwrap();
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("  /Whitespace Child    Col 1       /   "))
+            .unwrap();
 
     assert_eq!(segments.len(), 1);
 
-    assert_eq!(segments[0].name, "Whitespace Child  Col 1");
+    assert_eq!(segments[0].name, "Whitespace Child Col 1");
     assert_eq!(segments[0].fsname, "whitespace-child-col-1");
 }
 
@@ -126,4 +123,33 @@ fn to_sanitized_segments_backslash() {
     assert_eq!(segments.len(), 1);
     assert_eq!(segments[0].name, "Path-With-Backslashes");
     assert_eq!(segments[0].fsname, "path-with-backslashes");
+}
+
+#[test]
+fn to_sanitized_segments_backslash_at_ends() {
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("\\Path\\With\\Backslashes\\At\\Ends\\"))
+            .unwrap();
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].name, "Path-With-Backslashes-At-Ends");
+    assert_eq!(segments[0].fsname, "path-with-backslashes-at-ends");
+}
+
+#[test]
+fn to_sanitized_segments_multiple_consecutive_backslashes() {
+    let segments = utils::to_sanitized_segments(&PathBuf::from(
+        "\\Path\\With\\\\\\\\Multiple\\Consecutive\\\\\\\\Backslashes",
+    ))
+    .unwrap();
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(
+        segments[0].name,
+        "Path-With-Multiple-Consecutive-Backslashes"
+    );
+    assert_eq!(
+        segments[0].fsname,
+        "path-with-multiple-consecutive-backslashes"
+    );
 }

--- a/src-tauri/src/utils/tests.rs
+++ b/src-tauri/src/utils/tests.rs
@@ -3,10 +3,9 @@ use std::path::PathBuf;
 
 #[test]
 fn to_sanitized_segments_basic() {
-    let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"),
-    )
-    .unwrap();
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("Parent Col 1/Child Col 1/Grand Child Col 1"))
+            .unwrap();
 
     assert_eq!(segments.len(), 3);
 
@@ -40,16 +39,15 @@ fn to_sanitized_segments_with_whitespace_segments() {
 
 #[test]
 fn to_sanitized_segments_with_only_empty_segments() {
-    let segments =
-        utils::to_sanitized_segments(&PathBuf::from("   /   /   ")).unwrap();
+    let segments = utils::to_sanitized_segments(&PathBuf::from("   /   /   ")).unwrap();
     assert!(segments.is_empty());
 }
 
 #[test]
 fn to_sanitized_segments_special_characters() {
-    let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Special@Chars Col 1/Unicode# Col 2/🔥 Emoji Col 3"),
-    )
+    let segments = utils::to_sanitized_segments(&PathBuf::from(
+        "Special@Chars Col 1/Unicode# Col 2/🔥 Emoji Col 3",
+    ))
     .unwrap();
 
     assert_eq!(segments.len(), 3);
@@ -66,10 +64,9 @@ fn to_sanitized_segments_special_characters() {
 
 #[test]
 fn to_sanitized_segments_unicode() {
-    let segments = utils::to_sanitized_segments(
-        &PathBuf::from("ザク Unicode Col 1/設定 Unicode Col 2"),
-    )
-    .unwrap();
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("ザク Unicode Col 1/設定 Unicode Col 2"))
+            .unwrap();
 
     assert_eq!(segments.len(), 2);
 
@@ -82,10 +79,9 @@ fn to_sanitized_segments_unicode() {
 
 #[test]
 fn to_sanitized_segments_invalid_characters() {
-    let segments = utils::to_sanitized_segments(
-        &PathBuf::from("Parent|Invalid/Child::Col/Grand?Child*"),
-    )
-    .unwrap();
+    let segments =
+        utils::to_sanitized_segments(&PathBuf::from("Parent|Invalid/Child::Col/Grand?Child*"))
+            .unwrap();
 
     assert_eq!(segments.len(), 3);
     assert_eq!(segments[0].name, "Parent|Invalid");

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -202,8 +202,8 @@ export type CollectionMeta = {
     relpath: string;
 };
 export type CreateCollectionDto = { location_relpath: string; relpath: string };
-export type CreateNewCollection = { parent_relpath: string; relpath: string };
-export type CreateNewRequest = { parent_relpath: string; relpath: string };
+export type CreateNewCollection = { location_relpath: string; relpath: string };
+export type CreateNewRequest = { location_relpath: string; relpath: string };
 export type CreateRequestDto = { location_relpath: string; relpath: string };
 export type CreateSpaceDto = { name: string; location: string };
 export type DispatchNotificationOptions = { title: string; body: string };
@@ -238,7 +238,7 @@ export type HttpRes = {
     size_bytes?: number;
     elapsed_ms?: number;
 };
-export type MoveTreeNodeDto = { node_type: NodeType; from_relpath: string; to_relpath: string };
+export type MoveTreeNodeDto = { node_type: NodeType; cur_relpath: string; nxt_relpath: string };
 export type NodeType = "collection" | "request";
 export type NotificationSettings = { audio: AudioNotification };
 export type OpenDirDialogOpt = { title: string | null };

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -142,17 +142,12 @@ export const commands = {
     },
     async writeReqToSpaceBuffer(
         spaceAbspath: string,
-        relpath: string,
         request: HttpReq,
     ): Promise<Result<null, CmdErr>> {
         try {
             return {
                 status: "ok",
-                data: await TAURI_INVOKE("write_req_to_space_buffer", {
-                    spaceAbspath,
-                    relpath,
-                    request,
-                }),
+                data: await TAURI_INVOKE("write_req_to_space_buffer", { spaceAbspath, request }),
             };
         } catch (e) {
             if (e instanceof Error) throw e;
@@ -200,7 +195,12 @@ export const commands = {
 export type AudioNotification = { on_req_finish: boolean };
 export type CmdErr = { kind: ErrorKind; message: string; details: string | null };
 export type Collection = { meta: CollectionMeta; requests: HttpReq[]; collections: Collection[] };
-export type CollectionMeta = { fsname: string; name: string | null; is_expanded: boolean };
+export type CollectionMeta = {
+    fsname: string;
+    name: string | null;
+    is_expanded: boolean;
+    relpath: string;
+};
 export type CreateCollectionDto = { location_relpath: string; relpath: string };
 export type CreateNewCollection = { parent_relpath: string; relpath: string };
 export type CreateNewRequest = { parent_relpath: string; relpath: string };
@@ -238,7 +238,7 @@ export type HttpRes = {
     size_bytes?: number;
     elapsed_ms?: number;
 };
-export type MoveTreeNodeDto = { node_type: NodeType; src_relpath: string; dest_relpath: string };
+export type MoveTreeNodeDto = { node_type: NodeType; from_relpath: string; to_relpath: string };
 export type NodeType = "collection" | "request";
 export type NotificationSettings = { audio: AudioNotification };
 export type OpenDirDialogOpt = { title: string | null };
@@ -251,7 +251,12 @@ export type ReqCfg = {
     content_type?: string;
     body?: string;
 };
-export type ReqMeta = { fsname: string; name: string; has_unsaved_changes: boolean };
+export type ReqMeta = {
+    fsname: string;
+    name: string;
+    has_unsaved_changes: boolean;
+    relpath: string;
+};
 export type ReqStatus = "Idle" | "Pending" | "Success" | "Error";
 export type ReqUrl = {
     raw?: string;

--- a/src/lib/components/sidebar/sidebar.svelte
+++ b/src/lib/components/sidebar/sidebar.svelte
@@ -13,7 +13,6 @@
         TooltipContent,
         TooltipProvider,
     } from "$lib/components/primitives/tooltip";
-    import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
     import { Path } from "$lib/utils/path";
     import { explorerState } from "$lib/state.svelte";
     import {
@@ -46,17 +45,10 @@
 
     let { pane, isCollapsed = $bindable() }: Props = $props();
 
+    const rootRelpath = Path.from("");
+
     let spaceSettingsStr: string = $state(
         sharedState.space ? JSON.stringify(sharedState.space.settings) : String(),
-    );
-
-    let shouldRenderCreateNewRequestInput = $derived(
-        explorerActionsState.createNewNode === "request" &&
-            explorerState.focussedNode.relpath.startsWith(Path.from(RELATIVE_SPACE_ROOT)),
-    );
-    let shouldRenderCreateNewCollectionInput = $derived(
-        explorerActionsState.createNewNode === "collection" &&
-            explorerState.focussedNode.relpath.startsWith(Path.from(RELATIVE_SPACE_ROOT)),
     );
 </script>
 
@@ -212,10 +204,7 @@
                     <Tooltip delayDuration={500} disableHoverableContent>
                         <TooltipTrigger
                             class={cn(
-                                buttonVariants({
-                                    variant: "ghost",
-                                    size: "icon",
-                                }),
+                                buttonVariants({ variant: "ghost", size: "icon" }),
                                 "my-1.5 flex-shrink-0",
                             )}
                             onclick={() => {
@@ -234,10 +223,10 @@
                         Explorer
                     </p>
                     <TreeNodeRoot root={spaceSnapshot.root_collection}>
-                        {#if shouldRenderCreateNewRequestInput}
+                        {#if explorerActionsState.createNewNode === "request" && explorerState.isCreateNewNodeParent(rootRelpath)}
                             <TreeNodeCreate
                                 type="request"
-                                parentRelativePath={RELATIVE_SPACE_ROOT}
+                                locationRelpath={rootRelpath}
                                 level={1}
                             />
                         {/if}
@@ -245,10 +234,10 @@
                             <TreeNodeContent trail={[]} node={request} level={1} />
                         {/each}
 
-                        {#if shouldRenderCreateNewCollectionInput}
+                        {#if explorerActionsState.createNewNode === "collection" && explorerState.isCreateNewNodeParent(rootRelpath)}
                             <TreeNodeCreate
                                 type="collection"
-                                parentRelativePath={RELATIVE_SPACE_ROOT}
+                                locationRelpath={rootRelpath}
                                 level={1}
                             />
                         {/if}

--- a/src/lib/components/sidebar/sidebar.svelte
+++ b/src/lib/components/sidebar/sidebar.svelte
@@ -244,13 +244,7 @@
                             />
                         {/if}
                         {#each spaceSnapshot.root_collection.requests as request (request.meta.fsname)}
-                            <TreeNodeContent
-                                parentRelpath={RELATIVE_SPACE_ROOT}
-                                parentNames={[]}
-                                currentPath={request.meta.fsname}
-                                node={request}
-                                level={1}
-                            />
+                            <TreeNodeContent parents={[]} node={request} level={1} />
                         {/each}
 
                         {#if shouldRenderCreateNewCollectionInput}
@@ -261,13 +255,7 @@
                             />
                         {/if}
                         {#each spaceSnapshot.root_collection.collections as collection (collection.meta.fsname)}
-                            <TreeNodeContent
-                                parentRelpath={RELATIVE_SPACE_ROOT}
-                                parentNames={[]}
-                                currentPath={collection.meta.fsname}
-                                node={collection}
-                                level={1}
-                            />
+                            <TreeNodeContent parents={[]} node={collection} level={1} />
                         {/each}
                     </TreeNodeRoot>
                 </div>

--- a/src/lib/components/sidebar/sidebar.svelte
+++ b/src/lib/components/sidebar/sidebar.svelte
@@ -14,7 +14,8 @@
         TooltipProvider,
     } from "$lib/components/primitives/tooltip";
     import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
-    import { isCurrentCollectionOrAnyOfItsChildFocussed } from "$lib/components/tree-node/utils.svelte";
+    import { Path } from "$lib/utils/path";
+    import { explorerState } from "$lib/state.svelte";
     import {
         Dialog,
         DialogTrigger,
@@ -51,11 +52,11 @@
 
     let shouldRenderCreateNewRequestInput = $derived(
         explorerActionsState.createNewNode === "request" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(RELATIVE_SPACE_ROOT),
+            explorerState.focussedNode.relpath.startsWith(Path.from(RELATIVE_SPACE_ROOT)),
     );
     let shouldRenderCreateNewCollectionInput = $derived(
         explorerActionsState.createNewNode === "collection" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(RELATIVE_SPACE_ROOT),
+            explorerState.focussedNode.relpath.startsWith(Path.from(RELATIVE_SPACE_ROOT)),
     );
 </script>
 
@@ -232,10 +233,7 @@
                     <p class="text-muted-foreground flex h-[36px] items-center px-[22px]">
                         Explorer
                     </p>
-                    <TreeNodeRoot
-                        currentPath={RELATIVE_SPACE_ROOT}
-                        root={spaceSnapshot.root_collection}
-                    >
+                    <TreeNodeRoot root={spaceSnapshot.root_collection}>
                         {#if shouldRenderCreateNewRequestInput}
                             <TreeNodeCreate
                                 type="request"
@@ -244,7 +242,7 @@
                             />
                         {/if}
                         {#each spaceSnapshot.root_collection.requests as request (request.meta.fsname)}
-                            <TreeNodeContent parents={[]} node={request} level={1} />
+                            <TreeNodeContent trail={[]} node={request} level={1} />
                         {/each}
 
                         {#if shouldRenderCreateNewCollectionInput}
@@ -255,7 +253,7 @@
                             />
                         {/if}
                         {#each spaceSnapshot.root_collection.collections as collection (collection.meta.fsname)}
-                            <TreeNodeContent parents={[]} node={collection} level={1} />
+                            <TreeNodeContent trail={[]} node={collection} level={1} />
                         {/each}
                     </TreeNodeRoot>
                 </div>

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -22,9 +22,6 @@
     let { trail, node, level, class: className }: Props = $props();
 
     const relpath = Path.from(node.meta.relpath);
-    let shouldHighlight = $derived(isDropAllowed(node.meta.relpath));
-
-    const parentRelpath = relpath.parent()?.toString() ?? "";
 
     function handleTreeItemFocus(node: TreeNode) {
         if (isCol(node)) {
@@ -49,9 +46,13 @@
 </script>
 
 <div
-    data-parent-path={parentRelpath}
+    data-parent-path={relpath.parent()?.toString() ?? ""}
     data-current-path={node.meta.relpath}
-    class={cn("relative min-w-full", shouldHighlight ? "bg-accent/75" : "", className)}
+    class={cn(
+        "relative min-w-full",
+        isDropAllowed(node.meta.relpath) ? "bg-accent/75" : "",
+        className,
+    )}
 >
     {#if level > 1}
         <div

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -14,10 +14,10 @@
         handleDragOver,
         handleDrop,
         handleDragEnd,
-        buildPath,
         isCol,
         isReq,
     } from "$lib/components/tree-node/utils.svelte";
+    import { Path } from "$lib/utils/path";
 
     type Props = {
         parentRelpath: string;
@@ -160,11 +160,14 @@
         {/if}
 
         {#if node.meta.is_expanded}
-            {#each node.requests as request (buildPath(currentPath, request.meta.fsname))}
+            {#each node.requests as request (Path.from(currentPath)
+                .join(request.meta.fsname)
+                .toString())}
+                {@const relpath = Path.from(currentPath).join(request.meta.fsname).toString()}
                 <TreeNodeContent
                     parentRelpath={currentPath}
                     parentNames={[...parentNames, node.meta.name ?? node.meta.fsname]}
-                    currentPath={buildPath(currentPath, request.meta.fsname)}
+                    currentPath={relpath}
                     node={request}
                     level={level + 1}
                 />

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -19,57 +19,46 @@
     } from "$lib/components/tree-node/utils.svelte";
     import { Path } from "$lib/utils/path";
 
-    type Props = {
-        parentRelpath: string;
-        parentNames: string[];
-        currentPath: string;
-        node: TreeNode;
-        level: number;
-        class?: string;
-    };
-
-    let {
-        parentRelpath,
-        parentNames,
-        currentPath,
-        node,
-        level,
-        class: className,
-    }: Props = $props();
+    type Props = { parents: string[]; node: TreeNode; level: number; class?: string };
+    let { parents, node, level, class: className }: Props = $props();
 
     let shouldRenderCreateNewRequestInput = $derived(
         explorerActionsState.createNewNode === "request" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(currentPath),
+            isCurrentCollectionOrAnyOfItsChildFocussed(node.meta.relpath),
     );
     let shouldRenderCreateNewCollectionInput = $derived(
         explorerActionsState.createNewNode === "collection" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(currentPath),
+            isCurrentCollectionOrAnyOfItsChildFocussed(node.meta.relpath),
     );
-    let shouldHighlight = $derived(isDropAllowed(currentPath));
+    let shouldHighlight = $derived(isDropAllowed(node.meta.relpath));
+
+    const parentRelpath = Path.from(node.meta.relpath).parent()?.toString() ?? "";
 
     const dragOverDto: DragOverDto = isCol(node)
-        ? { type: "collection", relativePath: currentPath }
-        : { type: "request", parentRelativePath: parentRelpath };
+        ? { type: "collection", relativePath: node.meta.relpath }
+        : {
+              type: "request",
+              parentRelativePath: Path.from(node.meta.relpath).parent()?.toString() ?? "",
+          };
 
-    type TreeNodeFocusParams = { node: TreeNode; parentRelpath: string; relpath: string };
-    function handleTreeItemFocus({ node, parentRelpath, relpath }: TreeNodeFocusParams) {
+    function handleTreeItemFocus(node: TreeNode) {
         if (isCol(node)) {
             node.meta.is_expanded = !node.meta.is_expanded;
 
             explorerState.setFocussedNode({
                 type: "collection",
                 parentRelativePath: parentRelpath,
-                relativePath: relpath,
+                relativePath: node.meta.relpath,
             });
         } else if (isReq(node)) {
             explorerState.setFocussedNode({
                 type: "request",
                 parentRelativePath: parentRelpath,
-                relativePath: relpath,
+                relativePath: node.meta.relpath,
             });
 
             explorerState.setOpenRequest({
-                parentNames,
+                parents,
                 self: node,
             });
         } else {
@@ -80,7 +69,7 @@
 
 <div
     data-parent-path={parentRelpath}
-    data-current-path={currentPath}
+    data-current-path={node.meta.relpath}
     class={cn("relative min-w-full", shouldHighlight ? "bg-accent/75" : "", className)}
 >
     {#if level > 1}
@@ -104,20 +93,20 @@
             if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") {
                 keyboardEvent.preventDefault();
 
-                handleTreeItemFocus({ node, parentRelpath: parentRelpath, relpath: currentPath });
+                handleTreeItemFocus(node);
             }
         }}
         style="padding-left: {level * 8}px"
         class={cn(
             "focus-visible:ring-ring flex h-[22px] w-full items-center gap-2 overflow-hidden text-ellipsis whitespace-nowrap ring-inset focus-visible:ring-1 focus-visible:outline-none",
-            explorerState.focussedNode.relativePath === currentPath
+            explorerState.focussedNode.relativePath === node.meta.relpath
                 ? "bg-accent"
                 : "hover:bg-accent/75",
         )}
         onclick={() => {
             explorerActionsState.createNewNode = null;
 
-            handleTreeItemFocus({ node, parentRelpath: parentRelpath, relpath: currentPath });
+            handleTreeItemFocus(node);
         }}
     >
         <div class="flex size-full items-center gap-1 pl-1.5">
@@ -156,18 +145,20 @@
 
     {#if isCol(node)}
         {#if shouldRenderCreateNewRequestInput}
-            <TreeNodeCreate type="request" parentRelativePath={currentPath} level={level + 1} />
+            <TreeNodeCreate
+                type="request"
+                parentRelativePath={node.meta.relpath}
+                level={level + 1}
+            />
         {/if}
 
         {#if node.meta.is_expanded}
-            {#each node.requests as request (Path.from(currentPath)
+            {#each node.requests as request (Path.from(node.meta.relpath)
                 .join(request.meta.fsname)
                 .toString())}
-                {@const relpath = Path.from(currentPath).join(request.meta.fsname).toString()}
+                {@const relpath = Path.from(node.meta.relpath).join(request.meta.fsname).toString()}
                 <TreeNodeContent
-                    parentRelpath={currentPath}
-                    parentNames={[...parentNames, node.meta.name ?? node.meta.fsname]}
-                    currentPath={relpath}
+                    parents={[...parents, node.meta.name ?? node.meta.fsname]}
                     node={request}
                     level={level + 1}
                 />
@@ -175,14 +166,18 @@
         {/if}
 
         {#if shouldRenderCreateNewCollectionInput}
-            <TreeNodeCreate type="collection" parentRelativePath={currentPath} level={level + 1} />
+            <TreeNodeCreate
+                type="collection"
+                parentRelativePath={node.meta.relpath}
+                level={level + 1}
+            />
         {/if}
         {#if node.meta.is_expanded}
-            {#each node.collections as collection (buildPath(currentPath, collection.meta.fsname))}
+            {#each node.collections as collection (Path.from(node.meta.relpath)
+                .join(collection.meta.fsname)
+                .toString())}
                 <TreeNodeContent
-                    parentRelpath={currentPath}
-                    parentNames={[...parentNames, node.meta.name ?? node.meta.fsname]}
-                    currentPath={buildPath(currentPath, collection.meta.fsname)}
+                    parents={[...parents, node.meta.name ?? node.meta.fsname]}
                     node={collection}
                     level={level + 1}
                 />

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -21,29 +21,22 @@
     type Props = { trail: string[]; node: TreeNode; level: number; class?: string };
     let { trail, node, level, class: className }: Props = $props();
 
-    let shouldRenderCreateNewRequestInput = $derived(
-        explorerActionsState.createNewNode === "request" &&
-            explorerState.focussedNode.relpath.startsWith(Path.from(node.meta.relpath)),
-    );
-    let shouldRenderCreateNewCollectionInput = $derived(
-        explorerActionsState.createNewNode === "collection" &&
-            explorerState.focussedNode.relpath.startsWith(Path.from(node.meta.relpath)),
-    );
+    const relpath = Path.from(node.meta.relpath);
     let shouldHighlight = $derived(isDropAllowed(node.meta.relpath));
 
-    const parentRelpath = Path.from(node.meta.relpath).parent()?.toString() ?? "";
+    const parentRelpath = relpath.parent()?.toString() ?? "";
 
     function handleTreeItemFocus(node: TreeNode) {
         if (isCol(node)) {
             node.meta.is_expanded = !node.meta.is_expanded;
             explorerState.setFocussedNode({
                 type: "collection",
-                relpath: Path.from(node.meta.relpath),
+                relpath: relpath,
             });
         } else if (isReq(node)) {
             explorerState.setFocussedNode({
                 type: "request",
-                relpath: Path.from(node.meta.relpath),
+                relpath: relpath,
             });
             explorerState.setOpenRequest({
                 trail,
@@ -77,7 +70,7 @@
         ondragover={event => {
             handleDragOver(event, {
                 type: isCol(node) ? "collection" : "request",
-                relpath: Path.from(node.meta.relpath),
+                relpath: relpath,
             });
         }}
         ondrop={handleDrop}
@@ -137,18 +130,12 @@
     </div>
 
     {#if isCol(node)}
-        {#if shouldRenderCreateNewRequestInput}
-            <TreeNodeCreate
-                type="request"
-                parentRelativePath={node.meta.relpath}
-                level={level + 1}
-            />
+        {#if explorerActionsState.createNewNode === "request" && explorerState.isCreateNewNodeParent(relpath)}
+            <TreeNodeCreate type="request" locationRelpath={relpath} level={level + 1} />
         {/if}
 
         {#if node.meta.is_expanded}
-            {#each node.requests as request (Path.from(node.meta.relpath)
-                .join(request.meta.fsname)
-                .toString())}
+            {#each node.requests as request (relpath.join(request.meta.fsname).toString())}
                 <TreeNodeContent
                     trail={[...trail, node.meta.name ?? node.meta.fsname]}
                     node={request}
@@ -157,17 +144,11 @@
             {/each}
         {/if}
 
-        {#if shouldRenderCreateNewCollectionInput}
-            <TreeNodeCreate
-                type="collection"
-                parentRelativePath={node.meta.relpath}
-                level={level + 1}
-            />
+        {#if explorerActionsState.createNewNode === "collection" && explorerState.isCreateNewNodeParent(relpath)}
+            <TreeNodeCreate type="collection" locationRelpath={relpath} level={level + 1} />
         {/if}
         {#if node.meta.is_expanded}
-            {#each node.collections as collection (Path.from(node.meta.relpath)
-                .join(collection.meta.fsname)
-                .toString())}
+            {#each node.collections as collection (relpath.join(collection.meta.fsname).toString())}
                 <TreeNodeContent
                     trail={[...trail, node.meta.name ?? node.meta.fsname]}
                     node={collection}

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -69,7 +69,6 @@
             });
 
             explorerState.setOpenRequest({
-                parentRelpath: parentRelpath,
                 parentNames,
                 self: node,
             });

--- a/src/lib/components/tree-node/tree-node-content.svelte
+++ b/src/lib/components/tree-node/tree-node-content.svelte
@@ -3,12 +3,11 @@
     import { toast } from "svelte-sonner";
 
     import { TreeNodeContent, TreeNodeCreate } from ".";
-    import type { TreeNode, DragOverDto } from "$lib/models";
+    import type { TreeNode } from "$lib/models";
     import { explorerActionsState, explorerState } from "$lib/state.svelte";
     import { cn, requestColors } from "$lib/utils/style";
     import { CollectionIcon, DotIcon } from "$lib/components/icons";
     import {
-        isCurrentCollectionOrAnyOfItsChildFocussed,
         isDropAllowed,
         handleDragStart,
         handleDragOver,
@@ -19,46 +18,35 @@
     } from "$lib/components/tree-node/utils.svelte";
     import { Path } from "$lib/utils/path";
 
-    type Props = { parents: string[]; node: TreeNode; level: number; class?: string };
-    let { parents, node, level, class: className }: Props = $props();
+    type Props = { trail: string[]; node: TreeNode; level: number; class?: string };
+    let { trail, node, level, class: className }: Props = $props();
 
     let shouldRenderCreateNewRequestInput = $derived(
         explorerActionsState.createNewNode === "request" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(node.meta.relpath),
+            explorerState.focussedNode.relpath.startsWith(Path.from(node.meta.relpath)),
     );
     let shouldRenderCreateNewCollectionInput = $derived(
         explorerActionsState.createNewNode === "collection" &&
-            isCurrentCollectionOrAnyOfItsChildFocussed(node.meta.relpath),
+            explorerState.focussedNode.relpath.startsWith(Path.from(node.meta.relpath)),
     );
     let shouldHighlight = $derived(isDropAllowed(node.meta.relpath));
 
     const parentRelpath = Path.from(node.meta.relpath).parent()?.toString() ?? "";
 
-    const dragOverDto: DragOverDto = isCol(node)
-        ? { type: "collection", relativePath: node.meta.relpath }
-        : {
-              type: "request",
-              parentRelativePath: Path.from(node.meta.relpath).parent()?.toString() ?? "",
-          };
-
     function handleTreeItemFocus(node: TreeNode) {
         if (isCol(node)) {
             node.meta.is_expanded = !node.meta.is_expanded;
-
             explorerState.setFocussedNode({
                 type: "collection",
-                parentRelativePath: parentRelpath,
-                relativePath: node.meta.relpath,
+                relpath: Path.from(node.meta.relpath),
             });
         } else if (isReq(node)) {
             explorerState.setFocussedNode({
                 type: "request",
-                parentRelativePath: parentRelpath,
-                relativePath: node.meta.relpath,
+                relpath: Path.from(node.meta.relpath),
             });
-
             explorerState.setOpenRequest({
-                parents,
+                trail,
                 self: node,
             });
         } else {
@@ -84,9 +72,14 @@
         aria-grabbed="false"
         draggable="true"
         ondragstart={event => {
-            handleDragStart(event, { parentRelativePath: parentRelpath, node });
+            handleDragStart(event, node);
         }}
-        ondragover={event => handleDragOver(event, dragOverDto)}
+        ondragover={event => {
+            handleDragOver(event, {
+                type: isCol(node) ? "collection" : "request",
+                relpath: Path.from(node.meta.relpath),
+            });
+        }}
         ondrop={handleDrop}
         ondragend={handleDragEnd}
         onkeydown={keyboardEvent => {
@@ -99,7 +92,7 @@
         style="padding-left: {level * 8}px"
         class={cn(
             "focus-visible:ring-ring flex h-[22px] w-full items-center gap-2 overflow-hidden text-ellipsis whitespace-nowrap ring-inset focus-visible:ring-1 focus-visible:outline-none",
-            explorerState.focussedNode.relativePath === node.meta.relpath
+            explorerState.focussedNode.relpath.toString() === node.meta.relpath
                 ? "bg-accent"
                 : "hover:bg-accent/75",
         )}
@@ -156,9 +149,8 @@
             {#each node.requests as request (Path.from(node.meta.relpath)
                 .join(request.meta.fsname)
                 .toString())}
-                {@const relpath = Path.from(node.meta.relpath).join(request.meta.fsname).toString()}
                 <TreeNodeContent
-                    parents={[...parents, node.meta.name ?? node.meta.fsname]}
+                    trail={[...trail, node.meta.name ?? node.meta.fsname]}
                     node={request}
                     level={level + 1}
                 />
@@ -177,7 +169,7 @@
                 .join(collection.meta.fsname)
                 .toString())}
                 <TreeNodeContent
-                    parents={[...parents, node.meta.name ?? node.meta.fsname]}
+                    trail={[...trail, node.meta.name ?? node.meta.fsname]}
                     node={collection}
                     level={level + 1}
                 />

--- a/src/lib/components/tree-node/tree-node-create.svelte
+++ b/src/lib/components/tree-node/tree-node-create.svelte
@@ -11,13 +11,13 @@
     import { emitCmdError } from "$lib/utils";
 
     type Props = {
-        parentRelativePath: string;
+        locationRelpath: Path;
         type: "collection" | "request";
         level: number;
         class?: string;
     };
 
-    let { parentRelativePath, type, level, class: className }: Props = $props();
+    let { locationRelpath, type, level, class: className }: Props = $props();
 
     let inputRelpath: string = $state("");
     let inputElement: HTMLElement | null = $state(null);
@@ -41,7 +41,7 @@
     async function handleCreateRequestOrCollection() {
         if (type === "collection") {
             const createCollectionResult = await commands.createCollection({
-                location_relpath: parentRelativePath,
+                location_relpath: locationRelpath.toString(),
                 relpath: inputRelpath,
             });
             if (createCollectionResult.status !== "ok") {
@@ -64,7 +64,7 @@
             }
         } else {
             const createReqResult = await commands.createReq({
-                location_relpath: parentRelativePath,
+                location_relpath: locationRelpath.toString(),
                 relpath: inputRelpath,
             });
             if (createReqResult.status !== "ok") {

--- a/src/lib/components/tree-node/tree-node-create.svelte
+++ b/src/lib/components/tree-node/tree-node-create.svelte
@@ -7,6 +7,7 @@
     import { cn, requestColors } from "$lib/utils/style";
     import { CollectionIcon } from "$lib/components/icons";
     import { commands } from "$lib/bindings";
+    import { Path } from "$lib/utils/path";
     import { emitCmdError } from "$lib/utils";
 
     type Props = {
@@ -52,8 +53,7 @@
 
             explorerState.setFocussedNode({
                 type: "collection",
-                parentRelativePath: createCollectionResult.data.parent_relpath,
-                relativePath: createCollectionResult.data.relpath,
+                relpath: Path.from(createCollectionResult.data.relpath),
             });
 
             const createdCollection = document.querySelector(
@@ -76,8 +76,7 @@
 
             explorerState.setFocussedNode({
                 type: "request",
-                parentRelativePath: createReqResult.data.parent_relpath,
-                relativePath: createReqResult.data.relpath,
+                relpath: Path.from(createReqResult.data.relpath),
             });
 
             const createdRequest = document.querySelector(

--- a/src/lib/components/tree-node/tree-node-root.svelte
+++ b/src/lib/components/tree-node/tree-node-root.svelte
@@ -25,13 +25,11 @@
     type Props = { root: Collection; children: Snippet; class?: string };
 
     let { root, children, class: className }: Props = $props();
-
-    let shouldHighlight = $derived(isDropAllowed(root.meta.relpath));
 </script>
 
 <div
     data-current-path={root.meta.relpath}
-    class={cn("min-w-full", shouldHighlight ? "bg-accent/75" : "", className)}
+    class={cn("min-w-full", isDropAllowed(root.meta.relpath) ? "bg-accent/75" : "", className)}
 >
     <div
         tabindex={0}

--- a/src/lib/components/tree-node/tree-node-root.svelte
+++ b/src/lib/components/tree-node/tree-node-root.svelte
@@ -13,23 +13,24 @@
         TooltipContent,
         TooltipProvider,
     } from "$lib/components/primitives/tooltip";
-    import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
+    import { Path } from "$lib/utils/path";
     import {
         handleDragEnd,
         handleDragOver,
         handleDrop,
+        isCol,
         isDropAllowed,
     } from "$lib/components/tree-node/utils.svelte";
 
-    type Props = { currentPath: string; root: Collection; children: Snippet; class?: string };
+    type Props = { root: Collection; children: Snippet; class?: string };
 
-    let { currentPath, root, children, class: className }: Props = $props();
+    let { root, children, class: className }: Props = $props();
 
-    let shouldHighlight = $derived(isDropAllowed(currentPath));
+    let shouldHighlight = $derived(isDropAllowed(root.meta.relpath));
 </script>
 
 <div
-    data-current-path={currentPath}
+    data-current-path={root.meta.relpath}
     class={cn("min-w-full", shouldHighlight ? "bg-accent/75" : "", className)}
 >
     <div
@@ -37,8 +38,12 @@
         role="button"
         aria-grabbed="false"
         draggable="false"
-        ondragover={event =>
-            handleDragOver(event, { type: "collection", relativePath: currentPath })}
+        ondragover={event => {
+            handleDragOver(event, {
+                type: isCol(root) ? "collection" : "request",
+                relpath: Path.from(root.meta.relpath),
+            });
+        }}
         ondrop={handleDrop}
         ondragend={handleDragEnd}
         onkeydown={keyboardEvent => {
@@ -47,8 +52,7 @@
                 root.meta.is_expanded = !root.meta.is_expanded;
                 explorerState.setFocussedNode({
                     type: "collection",
-                    relativePath: RELATIVE_SPACE_ROOT,
-                    parentRelativePath: RELATIVE_SPACE_ROOT,
+                    relpath: Path.from(root.meta.relpath),
                 });
             }
         }}
@@ -59,8 +63,7 @@
             root.meta.is_expanded = !root.meta.is_expanded;
             explorerState.setFocussedNode({
                 type: "collection",
-                relativePath: RELATIVE_SPACE_ROOT,
-                parentRelativePath: RELATIVE_SPACE_ROOT,
+                relpath: Path.from(root.meta.relpath),
             });
         }}
     >
@@ -151,11 +154,12 @@
                 role="button"
                 aria-grabbed="false"
                 draggable="false"
-                ondragover={event =>
+                ondragover={event => {
                     handleDragOver(event, {
-                        type: "collection",
-                        relativePath: currentPath,
-                    })}
+                        type: isCol(root) ? "collection" : "request",
+                        relpath: Path.from(root.meta.relpath),
+                    });
+                }}
                 ondrop={handleDrop}
                 ondragend={handleDragEnd}
             ></div>

--- a/src/lib/components/tree-node/utils.svelte.ts
+++ b/src/lib/components/tree-node/utils.svelte.ts
@@ -112,8 +112,8 @@ export async function handleDrop(event: DragEvent) {
 
     const moveTreeNodeResult = await commands.moveTreeNode({
         node_type: isCol(explorerActionsState.dragNode) ? "collection" : "request",
-        from_relpath: explorerActionsState.dragNodePath.toString(),
-        to_relpath: explorerActionsState.dropNodePath
+        cur_relpath: explorerActionsState.dragNodePath.toString(),
+        nxt_relpath: explorerActionsState.dropNodePath
             .join(explorerActionsState.dragNode.meta.fsname)
             .toString(),
     });

--- a/src/lib/components/tree-node/utils.svelte.ts
+++ b/src/lib/components/tree-node/utils.svelte.ts
@@ -111,18 +111,14 @@ export async function handleDrop(event: DragEvent) {
         return;
     }
 
-    const from_relpath = Path.from(explorerActionsState.dragPayload.parentRelativePath)
-        .join(explorerActionsState.dragPayload.node.meta.fsname)
-        .toString();
-    const to_relpath = Path.from(explorerActionsState.dropTargetPath)
-        .join(explorerActionsState.dragPayload.node.meta.fsname)
-        .toString();
-    const node_type = isCol(explorerActionsState.dragPayload.node) ? "collection" : "request";
-
     const moveTreeNodeResult = await commands.moveTreeNode({
-        node_type,
-        from_relpath,
-        to_relpath,
+        node_type: isCol(explorerActionsState.dragPayload.node) ? "collection" : "request",
+        from_relpath: Path.from(explorerActionsState.dragPayload.parentRelativePath)
+            .join(explorerActionsState.dragPayload.node.meta.fsname)
+            .toString(),
+        to_relpath: Path.from(explorerActionsState.dropTargetPath)
+            .join(explorerActionsState.dragPayload.node.meta.fsname)
+            .toString(),
     });
     if (moveTreeNodeResult.status !== "ok") {
         return emitCmdError(moveTreeNodeResult.error);

--- a/src/lib/components/tree-node/utils.svelte.ts
+++ b/src/lib/components/tree-node/utils.svelte.ts
@@ -128,11 +128,11 @@ export async function handleDrop(event: DragEvent) {
         return;
     }
 
-    const src_relpath = buildPath(
+    const from_relpath = buildPath(
         explorerActionsState.dragPayload.parentRelativePath,
         explorerActionsState.dragPayload.node.meta.fsname,
     );
-    const dest_relpath = buildPath(
+    const to_relpath = buildPath(
         explorerActionsState.dropTargetPath,
         explorerActionsState.dragPayload.node.meta.fsname,
     );
@@ -140,8 +140,8 @@ export async function handleDrop(event: DragEvent) {
 
     const moveTreeNodeResult = await commands.moveTreeNode({
         node_type,
-        src_relpath,
-        dest_relpath,
+        from_relpath,
+        to_relpath,
     });
     if (moveTreeNodeResult.status !== "ok") {
         return emitCmdError(moveTreeNodeResult.error);

--- a/src/lib/components/tree-node/utils.svelte.ts
+++ b/src/lib/components/tree-node/utils.svelte.ts
@@ -2,8 +2,8 @@ import { mount, unmount } from "svelte";
 import { toast } from "svelte-sonner";
 
 import { TreeNodePreview } from "$lib/components/tree-node";
-import { sharedState, explorerActionsState, explorerState } from "$lib/state.svelte";
-import type { DragOverDto, DragPayload, TreeNode } from "$lib/models";
+import { sharedState, explorerActionsState } from "$lib/state.svelte";
+import type { DragOverDto, TreeNode } from "$lib/models";
 import { Path } from "$lib/utils/path";
 import { commands } from "$lib/bindings";
 import type { Collection, HttpReq } from "$lib/bindings";
@@ -21,38 +21,32 @@ export function isReq(treeNode: TreeNode): treeNode is HttpReq {
     );
 }
 
-export function pathJoin(paths: string[]) {
-    return paths.reduce((acc, segment) => Path.from(acc).join(segment).toString(), "");
-}
-
 export function isDropAllowed(path: string): boolean {
-    if (explorerActionsState.dropTargetPath !== null && explorerActionsState.dragPayload !== null) {
-        if (
-            explorerActionsState.dropTargetPath ===
-            explorerActionsState.dragPayload.parentRelativePath
-        ) {
+    if (
+        explorerActionsState.dropNodePath !== null &&
+        explorerActionsState.dragNode !== null &&
+        explorerActionsState.dragNodePath !== null
+    ) {
+        const dragParentPath = explorerActionsState.dragNodePath.parent() ?? Path.from("");
+
+        if (explorerActionsState.dropNodePath.toString() === dragParentPath.toString()) {
             return false;
         }
 
-        if (isCol(explorerActionsState.dragPayload.node)) {
-            const dirName = explorerActionsState.dragPayload.node.meta.fsname;
-            const relativePath = Path.from(explorerActionsState.dragPayload.parentRelativePath)
-                .join(dirName)
-                .toString();
-
-            if (Path.from(relativePath).isChild(explorerActionsState.dropTargetPath)) {
+        if (isCol(explorerActionsState.dragNode)) {
+            if (explorerActionsState.dropNodePath.startsWith(explorerActionsState.dragNodePath)) {
                 return false;
             }
 
             return (
-                explorerActionsState.dropTargetPath === path &&
-                explorerActionsState.dropTargetPath !== relativePath
+                explorerActionsState.dropNodePath.toString() === path &&
+                explorerActionsState.dropNodePath.toString() !==
+                    explorerActionsState.dragNodePath.toString()
             );
         } else {
             return (
-                explorerActionsState.dropTargetPath === path &&
-                explorerActionsState.dropTargetPath !==
-                    explorerActionsState.dragPayload.parentRelativePath
+                explorerActionsState.dropNodePath.toString() === path &&
+                explorerActionsState.dropNodePath.toString() !== dragParentPath.toString()
             );
         }
     }
@@ -60,10 +54,11 @@ export function isDropAllowed(path: string): boolean {
     return false;
 }
 
-export function handleDragStart(event: DragEvent, payload: DragPayload) {
+export function handleDragStart(event: DragEvent, node: TreeNode) {
     event.stopImmediatePropagation();
 
-    explorerActionsState.dragPayload = payload;
+    explorerActionsState.dragNode = node;
+    explorerActionsState.dragNodePath = Path.from(node.meta.relpath);
 
     if (event.dataTransfer) {
         const previewContainer = document.createElement("div");
@@ -72,9 +67,9 @@ export function handleDragStart(event: DragEvent, payload: DragPayload) {
         previewContainer.style.left = "-1000px";
         document.body.appendChild(previewContainer);
 
-        const previewTitle = isCol(payload.node)
-            ? (payload.node.meta.name ?? payload.node.meta.fsname)
-            : (payload.node.meta.name ?? payload.node.meta.fsname);
+        const previewTitle = isCol(node)
+            ? (node.meta.name ?? node.meta.fsname)
+            : (node.meta.name ?? node.meta.fsname);
 
         const treeNodePreview = mount(TreeNodePreview, {
             target: previewContainer,
@@ -102,22 +97,24 @@ export async function handleDrop(event: DragEvent) {
     event.preventDefault();
     event.stopImmediatePropagation();
 
-    if (explorerActionsState.dragPayload === null) {
-        toast.error("Drag payload not found");
+    if (explorerActionsState.dragNode === null) {
+        toast.error("Drag node not found");
         return;
     }
-    if (explorerActionsState.dropTargetPath === null) {
+    if (explorerActionsState.dragNodePath === null) {
+        toast.error("Drag node path not found");
+        return;
+    }
+    if (explorerActionsState.dropNodePath === null) {
         toast.error("Drop target path not found");
         return;
     }
 
     const moveTreeNodeResult = await commands.moveTreeNode({
-        node_type: isCol(explorerActionsState.dragPayload.node) ? "collection" : "request",
-        from_relpath: Path.from(explorerActionsState.dragPayload.parentRelativePath)
-            .join(explorerActionsState.dragPayload.node.meta.fsname)
-            .toString(),
-        to_relpath: Path.from(explorerActionsState.dropTargetPath)
-            .join(explorerActionsState.dragPayload.node.meta.fsname)
+        node_type: isCol(explorerActionsState.dragNode) ? "collection" : "request",
+        from_relpath: explorerActionsState.dragNodePath.toString(),
+        to_relpath: explorerActionsState.dropNodePath
+            .join(explorerActionsState.dragNode.meta.fsname)
             .toString(),
     });
     if (moveTreeNodeResult.status !== "ok") {
@@ -132,9 +129,9 @@ export function handleDragOver(event: DragEvent, dragOverDto: DragOverDto) {
     event.stopImmediatePropagation();
 
     if (dragOverDto.type === "collection") {
-        explorerActionsState.dropTargetPath = dragOverDto.relativePath;
+        explorerActionsState.dropNodePath = dragOverDto.relpath;
     } else {
-        explorerActionsState.dropTargetPath = dragOverDto.parentRelativePath;
+        explorerActionsState.dropNodePath = dragOverDto.relpath.parent() ?? Path.from("");
     }
 }
 
@@ -145,16 +142,5 @@ export function handleDragEnd(event: DragEvent) {
         event.currentTarget.setAttribute("aria-grabbed", "false");
     }
 
-    explorerActionsState.dropTargetPath = null;
-}
-
-export function isCurrentCollectionOrAnyOfItsChildFocussed(currentPath: string): boolean {
-    const isCurrentCollectionFocussed =
-        explorerState.focussedNode.type === "collection" &&
-        explorerState.focussedNode.relativePath === currentPath;
-    const isCurrentCollectionChildFocussed =
-        explorerState.focussedNode.type === "request" &&
-        explorerState.focussedNode.parentRelativePath === currentPath;
-
-    return isCurrentCollectionFocussed || isCurrentCollectionChildFocussed;
+    explorerActionsState.dropNodePath = null;
 }

--- a/src/lib/components/tree-node/utils.svelte.ts
+++ b/src/lib/components/tree-node/utils.svelte.ts
@@ -4,7 +4,7 @@ import { toast } from "svelte-sonner";
 import { TreeNodePreview } from "$lib/components/tree-node";
 import { sharedState, explorerActionsState, explorerState } from "$lib/state.svelte";
 import type { DragOverDto, DragPayload, TreeNode } from "$lib/models";
-import { RELATIVE_SPACE_ROOT } from "$lib/utils/constants";
+import { Path } from "$lib/utils/path";
 import { commands } from "$lib/bindings";
 import type { Collection, HttpReq } from "$lib/bindings";
 import { emitCmdError } from "$lib/utils";
@@ -21,22 +21,8 @@ export function isReq(treeNode: TreeNode): treeNode is HttpReq {
     );
 }
 
-export function isSubPath(currentPath: string, targetPath: string): boolean {
-    const currentSegments = pathSegments(currentPath);
-    const targetPathSegments = pathSegments(targetPath);
-
-    return (
-        currentSegments.length <= targetPathSegments.length &&
-        currentSegments.every((segment, index) => segment === targetPathSegments[index])
-    );
-}
-
-export function pathSegments(path: string) {
-    return path.split("/").filter(segment => segment !== "");
-}
-
 export function pathJoin(paths: string[]) {
-    return paths.filter(segment => segment !== "").join("/");
+    return paths.reduce((acc, segment) => Path.from(acc).join(segment).toString(), "");
 }
 
 export function isDropAllowed(path: string): boolean {
@@ -50,14 +36,11 @@ export function isDropAllowed(path: string): boolean {
 
         if (isCol(explorerActionsState.dragPayload.node)) {
             const dirName = explorerActionsState.dragPayload.node.meta.fsname;
-            const relativePath =
-                explorerActionsState.dragPayload.parentRelativePath === RELATIVE_SPACE_ROOT
-                    ? explorerActionsState.dragPayload.parentRelativePath.concat(dirName)
-                    : explorerActionsState.dragPayload.parentRelativePath
-                          .concat("/")
-                          .concat(dirName);
+            const relativePath = Path.from(explorerActionsState.dragPayload.parentRelativePath)
+                .join(dirName)
+                .toString();
 
-            if (isSubPath(relativePath, explorerActionsState.dropTargetPath)) {
+            if (Path.from(relativePath).isChild(explorerActionsState.dropTargetPath)) {
                 return false;
             }
 
@@ -128,14 +111,12 @@ export async function handleDrop(event: DragEvent) {
         return;
     }
 
-    const from_relpath = buildPath(
-        explorerActionsState.dragPayload.parentRelativePath,
-        explorerActionsState.dragPayload.node.meta.fsname,
-    );
-    const to_relpath = buildPath(
-        explorerActionsState.dropTargetPath,
-        explorerActionsState.dragPayload.node.meta.fsname,
-    );
+    const from_relpath = Path.from(explorerActionsState.dragPayload.parentRelativePath)
+        .join(explorerActionsState.dragPayload.node.meta.fsname)
+        .toString();
+    const to_relpath = Path.from(explorerActionsState.dropTargetPath)
+        .join(explorerActionsState.dragPayload.node.meta.fsname)
+        .toString();
     const node_type = isCol(explorerActionsState.dragPayload.node) ? "collection" : "request";
 
     const moveTreeNodeResult = await commands.moveTreeNode({
@@ -169,10 +150,6 @@ export function handleDragEnd(event: DragEvent) {
     }
 
     explorerActionsState.dropTargetPath = null;
-}
-
-export function buildPath(currentPath: string, treeNodeName: string) {
-    return currentPath === RELATIVE_SPACE_ROOT ? treeNodeName : `${currentPath}/${treeNodeName}`;
 }
 
 export function isCurrentCollectionOrAnyOfItsChildFocussed(currentPath: string): boolean {

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,35 +1,19 @@
 import type { Collection, HttpReq } from "$lib/bindings";
+import { Path } from "$lib/utils/path";
 
 export type TreeNode = Collection | HttpReq;
 
-export type DragPayload = {
-    parentRelativePath: string;
-    node: TreeNode;
+export type DragOverDto = {
+    type: "collection" | "request";
+    relpath: Path;
 };
 
-export type DragOverDto =
-    | {
-          type: "collection";
-          relativePath: string;
-      }
-    | {
-          type: "request";
-          parentRelativePath: string;
-      };
-
-export type FocussedTreeNode =
-    | {
-          type: "collection";
-          parentRelativePath: string;
-          relativePath: string;
-      }
-    | {
-          type: "request";
-          parentRelativePath: string;
-          relativePath: string;
-      };
+export type FocussedTreeNode = {
+    type: "collection" | "request";
+    relpath: Path;
+};
 
 export type OpenRequest = {
-    parents: string[];
+    trail: string[];
     self: HttpReq;
 };

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -30,6 +30,6 @@ export type FocussedTreeNode =
       };
 
 export type OpenRequest = {
-    parentNames: string[];
+    parents: string[];
     self: HttpReq;
 };

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -30,7 +30,6 @@ export type FocussedTreeNode =
       };
 
 export type OpenRequest = {
-    parentRelpath: string;
     parentNames: string[];
     self: HttpReq;
 };

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -146,12 +146,6 @@ class Debounced {
             clearTimeout(timer);
         }
     }
-    public async flushAll(): Promise<void> {
-        for (const { timer, spaceAbspath, openRequest } of this.#state.values()) {
-            commands.writeReqToSpaceBuffer(spaceAbspath, openRequest.self);
-            clearTimeout(timer);
-        }
-    }
 }
 
 export const debounced = new Debounced();

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -69,10 +69,8 @@ class ExplorerState {
     }
 
     public setOpenRequest(openRequest: OpenRequest) {
-        const currentRelpath = this.openRequest
-            ? pathJoin([this.openRequest.parentRelpath, this.openRequest.self.meta.fsname])
-            : null;
-        const newRelpath = pathJoin([openRequest.parentRelpath, openRequest.self.meta.fsname]);
+        const currentRelpath = this.openRequest ? this.openRequest.self.meta.relpath : null;
+        const newRelpath = openRequest.self.meta.relpath;
 
         if (currentRelpath !== newRelpath) {
             this.openRequest = openRequest;
@@ -105,11 +103,7 @@ class Debounced {
     #DELAY = 1500;
 
     public saveReqToSpaceBuffer(absoluteSpacePath: string, openRequest: OpenRequest): void {
-        const absoluteRequestPath = pathJoin([
-            absoluteSpacePath,
-            openRequest.parentRelpath,
-            openRequest.self.meta.fsname,
-        ]);
+        const absoluteRequestPath = pathJoin([absoluteSpacePath, openRequest.self.meta.relpath]);
 
         const current = this.#state.get(absoluteRequestPath);
         if (current) {
@@ -117,11 +111,7 @@ class Debounced {
         }
 
         const timer = setTimeout(() => {
-            commands.writeReqToSpaceBuffer(
-                absoluteSpacePath,
-                openRequest.parentRelpath,
-                openRequest.self,
-            );
+            commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
 
             this.#state.delete(absoluteRequestPath);
         }, this.#DELAY);
@@ -139,22 +129,14 @@ class Debounced {
         const currentState = this.#state.get(absoluteRequestPath);
         if (currentState) {
             const { timer, absoluteSpacePath, openRequest } = currentState;
-            await commands.writeReqToSpaceBuffer(
-                absoluteSpacePath,
-                openRequest.parentRelpath,
-                openRequest.self,
-            );
+            await commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
             this.#state.delete(absoluteRequestPath);
             clearTimeout(timer);
         }
     }
     public async flushAll(): Promise<void> {
         for (const { timer, absoluteSpacePath, openRequest } of this.#state.values()) {
-            commands.writeReqToSpaceBuffer(
-                absoluteSpacePath,
-                openRequest.parentRelpath,
-                openRequest.self,
-            );
+            commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
             clearTimeout(timer);
         }
     }

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -82,6 +82,17 @@ class ExplorerState {
         }
     }
 
+    public isCreateNewNodeParent(relpath: Path): boolean {
+        const isCurCollectionFocussed =
+            this.focussedNode.type === "collection" &&
+            this.focussedNode.relpath.toString() === relpath.toString();
+        const isCurCollectionReqFocussed =
+            this.focussedNode.type === "request" &&
+            this.focussedNode.relpath.parent()?.toString() === relpath.toString();
+
+        return isCurCollectionFocussed || isCurCollectionReqFocussed;
+    }
+
     public reset() {
         this.focussedNode = this.#rootNode;
         this.openRequest = null;

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -2,7 +2,7 @@ import { tick } from "svelte";
 
 import { version } from "$app/environment";
 
-import type { OpenRequest, DragPayload, FocussedTreeNode } from "$lib/models";
+import type { OpenRequest, FocussedTreeNode, TreeNode } from "$lib/models";
 import { commands } from "$lib/bindings";
 import type { SpaceReference, Space, HttpReq, NodeType } from "$lib/bindings";
 import { Path } from "$lib/utils/path";
@@ -38,13 +38,15 @@ class SharedState {
 export const sharedState = new SharedState();
 
 class ExplorerActionsState {
-    public dragPayload: DragPayload | null = $state(null);
-    public dropTargetPath: string | null = $state(null);
+    public dragNode: TreeNode | null = $state(null);
+    public dragNodePath: Path | null = $state(null);
+    public dropNodePath: Path | null = $state(null);
     public createNewNode: NodeType | null = $state(null);
 
     public reset() {
-        this.dragPayload = null;
-        this.dropTargetPath = null;
+        this.dragNode = null;
+        this.dragNodePath = null;
+        this.dropNodePath = null;
         this.createNewNode = null;
     }
 }
@@ -54,17 +56,16 @@ export const explorerActionsState = new ExplorerActionsState();
 class ExplorerState {
     #rootNode: FocussedTreeNode = {
         type: "collection",
-        relativePath: "",
-        parentRelativePath: "",
+        relpath: Path.from(""),
     };
 
     public focussedNode: FocussedTreeNode = $state(this.#rootNode);
     public openRequest: OpenRequest | null = $state(null);
     public backgroundRequests: HttpReq[] = $state([]);
 
-    public setFocussedNode(node: FocussedTreeNode) {
-        if (this.focussedNode.relativePath !== node.relativePath) {
-            this.focussedNode = node;
+    public setFocussedNode(focussedNode: FocussedTreeNode) {
+        if (this.focussedNode.relpath.toString() !== focussedNode.relpath.toString()) {
+            this.focussedNode = focussedNode;
         }
     }
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -5,7 +5,7 @@ import { version } from "$app/environment";
 import type { OpenRequest, DragPayload, FocussedTreeNode } from "$lib/models";
 import { commands } from "$lib/bindings";
 import type { SpaceReference, Space, HttpReq, NodeType } from "$lib/bindings";
-import { pathJoin } from "$lib/components/tree-node/utils.svelte";
+import { Path } from "$lib/utils/path";
 import { emitCmdError } from "$lib/utils";
 
 class SharedState {
@@ -94,7 +94,7 @@ type AbsoluteRequestPath = string;
 
 type DebouncedState = {
     timer: number;
-    absoluteSpacePath: string;
+    spaceAbspath: string;
     openRequest: OpenRequest;
 };
 
@@ -102,41 +102,41 @@ class Debounced {
     #state: Map<AbsoluteRequestPath, DebouncedState> = new Map();
     #DELAY = 1500;
 
-    public saveReqToSpaceBuffer(absoluteSpacePath: string, openRequest: OpenRequest): void {
-        const absoluteRequestPath = pathJoin([absoluteSpacePath, openRequest.self.meta.relpath]);
+    public saveReqToSpaceBuffer(spaceAbspath: string, openRequest: OpenRequest): void {
+        const reqAbspath = Path.from(spaceAbspath).join(openRequest.self.meta.relpath).toString();
 
-        const current = this.#state.get(absoluteRequestPath);
+        const current = this.#state.get(reqAbspath);
         if (current) {
             clearTimeout(current.timer);
         }
 
         const timer = setTimeout(() => {
-            commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
+            commands.writeReqToSpaceBuffer(spaceAbspath, openRequest.self);
 
-            this.#state.delete(absoluteRequestPath);
+            this.#state.delete(reqAbspath);
         }, this.#DELAY);
 
-        this.#state.set(absoluteRequestPath, {
+        this.#state.set(reqAbspath, {
             timer,
-            absoluteSpacePath,
+            spaceAbspath,
             openRequest,
         });
     }
-    public isPending(absoluteRequestPath: string): boolean {
-        return this.#state.has(absoluteRequestPath);
+    public isPending(reqAbspath: string): boolean {
+        return this.#state.has(reqAbspath);
     }
-    public async flush(absoluteRequestPath: string): Promise<void> {
-        const currentState = this.#state.get(absoluteRequestPath);
+    public async flush(reqAbspath: string): Promise<void> {
+        const currentState = this.#state.get(reqAbspath);
         if (currentState) {
-            const { timer, absoluteSpacePath, openRequest } = currentState;
-            await commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
-            this.#state.delete(absoluteRequestPath);
+            const { timer, spaceAbspath, openRequest } = currentState;
+            await commands.writeReqToSpaceBuffer(spaceAbspath, openRequest.self);
+            this.#state.delete(reqAbspath);
             clearTimeout(timer);
         }
     }
     public async flushAll(): Promise<void> {
-        for (const { timer, absoluteSpacePath, openRequest } of this.#state.values()) {
-            commands.writeReqToSpaceBuffer(absoluteSpacePath, openRequest.self);
+        for (const { timer, spaceAbspath, openRequest } of this.#state.values()) {
+            commands.writeReqToSpaceBuffer(spaceAbspath, openRequest.self);
             clearTimeout(timer);
         }
     }

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -19,8 +19,6 @@ export const REQUEST_BODY_TYPES = {
     PlainText: "text/plain",
 } as const;
 
-export const RELATIVE_SPACE_ROOT = "";
-
 export const HTTP_STATUS_DESCRIPTION: Record<number, string> = {
     100: "Continue",
     101: "Switching Protocols",

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -1,0 +1,47 @@
+export class Path {
+    #segments: string[];
+
+    private constructor() {
+        this.#segments = [];
+    }
+
+    static from(path: string): Path {
+        const instance = new Path();
+        instance.#segments = path === "" ? [] : path.split("/").filter(segment => segment !== "");
+
+        return instance;
+    }
+
+    join(segment: string): Path {
+        if (segment === "") return this;
+
+        const instance = new Path();
+        instance.#segments = [...this.#segments, segment];
+
+        return instance;
+    }
+
+    isEmpty(): boolean {
+        return this.#segments.length === 0;
+    }
+
+    isChild(targetPath: string | Path): boolean {
+        const targetSegments =
+            typeof targetPath === "string"
+                ? Path.from(targetPath).toSegments()
+                : targetPath.toSegments();
+
+        return (
+            this.#segments.length <= targetSegments.length &&
+            this.#segments.every((segment, index) => segment === targetSegments[index])
+        );
+    }
+
+    toSegments(): string[] {
+        return [...this.#segments];
+    }
+
+    toString(): string {
+        return this.#segments.join("/");
+    }
+}

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -21,6 +21,20 @@ export class Path {
         return instance;
     }
 
+    parent(): Path | null {
+        if (this.#segments.length === 0) {
+            return null;
+        }
+        if (this.#segments.length === 1) {
+            return Path.from("");
+        }
+
+        const instance = new Path();
+        instance.#segments = this.#segments.slice(0, -1);
+
+        return instance;
+    }
+
     isEmpty(): boolean {
         return this.#segments.length === 0;
     }

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -1,24 +1,26 @@
 export class Path {
     #segments: string[];
+    static readonly separator = "/";
 
-    private constructor() {
-        this.#segments = [];
+    constructor(path?: string) {
+        this.#segments = path ? Path.toSegments(path) : [];
     }
 
     static from(path: string): Path {
-        const instance = new Path();
-        instance.#segments = path === "" ? [] : path.split("/").filter(segment => segment !== "");
-
-        return instance;
+        return new Path(path);
     }
 
-    join(segment: string): Path {
-        if (segment === "") return this;
+    static toSegments(path: string): string[] {
+        return path === "" ? [] : path.split(Path.separator).filter(segment => segment !== "");
+    }
 
-        const instance = new Path();
-        instance.#segments = [...this.#segments, segment];
+    join(path: string): Path {
+        if (path === "") return this;
 
-        return instance;
+        const newPath = new Path();
+        newPath.#segments = [...this.#segments, ...Path.toSegments(path)];
+
+        return newPath;
     }
 
     parent(): Path | null {
@@ -26,36 +28,27 @@ export class Path {
             return null;
         }
         if (this.#segments.length === 1) {
-            return Path.from("");
+            return new Path("");
         }
 
-        const instance = new Path();
-        instance.#segments = this.#segments.slice(0, -1);
+        const parentPath = new Path();
+        parentPath.#segments = this.#segments.slice(0, -1);
 
-        return instance;
+        return parentPath;
+    }
+
+    startsWith(prefix: Path): boolean {
+        return (
+            this.#segments.length >= prefix.#segments.length &&
+            prefix.#segments.every((segment, index) => segment === this.#segments[index])
+        );
     }
 
     isEmpty(): boolean {
         return this.#segments.length === 0;
     }
 
-    isChild(targetPath: string | Path): boolean {
-        const targetSegments =
-            typeof targetPath === "string"
-                ? Path.from(targetPath).toSegments()
-                : targetPath.toSegments();
-
-        return (
-            this.#segments.length <= targetSegments.length &&
-            this.#segments.every((segment, index) => segment === targetSegments[index])
-        );
-    }
-
-    toSegments(): string[] {
-        return [...this.#segments];
-    }
-
     toString(): string {
-        return this.#segments.join("/");
+        return this.#segments.join(Path.separator);
     }
 }

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -122,14 +122,13 @@
 
             const absoluteReqPath = pathJoin([
                 spaceSnapshot.abspath,
-                openReqSnapshot.parentRelpath,
-                openReqSnapshot.self.meta.fsname,
+                openReqSnapshot.self.meta.relpath,
             ]);
 
             await debounced.flush(absoluteReqPath);
             const writeReqbufToReqtomlResult = await commands.writeReqbufToReqtoml(
                 spaceSnapshot.abspath,
-                pathJoin([openReqSnapshot.parentRelpath, openReqSnapshot.self.meta.fsname]),
+                openReqSnapshot.self.meta.relpath,
             );
             if (writeReqbufToReqtomlResult.status !== "ok") {
                 return emitCmdError(writeReqbufToReqtomlResult.error);
@@ -142,9 +141,7 @@
 
     const openReqSnapshot = explorerState.openRequest;
     let isOpenReqSavedToFs = false;
-    let prevOpenReqRelPath = openReqSnapshot
-        ? pathJoin([openReqSnapshot.parentRelpath, openReqSnapshot.self.meta.fsname])
-        : null;
+    let prevOpenReqRelPath = openReqSnapshot ? openReqSnapshot.self.meta.relpath : null;
     let prevSpaceAbspath = sharedState.space ? sharedState.space.abspath : null;
 
     $effect(() => {
@@ -176,16 +173,11 @@
             return;
         }
 
-        const openReqRelPath = pathJoin([
-            openReqSnapshot.parentRelpath,
-            openReqSnapshot.self.meta.fsname,
-        ]);
-
-        if (prevOpenReqRelPath && prevOpenReqRelPath === openReqRelPath) {
+        if (prevOpenReqRelPath && prevOpenReqRelPath === openReqSnapshot.self.meta.relpath) {
             openReqSnapshot.self.meta.has_unsaved_changes = true;
             debounced.saveReqToSpaceBuffer(spaceSnapshot.abspath, openReqSnapshot);
         } else {
-            prevOpenReqRelPath = openReqRelPath;
+            prevOpenReqRelPath = openReqSnapshot.self.meta.relpath;
         }
     });
 </script>

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -139,14 +139,15 @@
     }
 
     const openReqSnapshot = explorerState.openRequest;
+    const spaceSnapshot = $state.snapshot(sharedState.space);
     let isOpenReqSavedToFs = false;
     let prevOpenReqRelPath = openReqSnapshot ? openReqSnapshot.self.meta.relpath : null;
     let prevSpaceAbspath = sharedState.space ? sharedState.space.abspath : null;
 
+    // Be very carefull when adding reactive state variables to this
     $effect(() => {
         // Important hack to keep the effect deeply reactive
         // Only watch config and metadata changes, not response/status
-        const spaceSnapshot = sharedState.space;
         const openReqSnapshot = explorerState.openRequest;
         if (openReqSnapshot) {
             JSON.stringify({

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -209,13 +209,13 @@
             {@const openReqSnapshot = explorerState.openRequest}
             {#if openReqSnapshot}
                 {@const MAX_PARENTS_TO_SHOW = 2}
-                {@const parentsOverflow = openReqSnapshot.parentNames.length > MAX_PARENTS_TO_SHOW}
+                {@const parentsOverflow = openReqSnapshot.parents.length > MAX_PARENTS_TO_SHOW}
                 <ResizablePaneGroup direction="vertical" class="size-full">
                     <div class="p-3">
                         <div class="mb-3 flex items-center gap-0.5">
-                            {#if openReqSnapshot.parentNames.length > 0}
+                            {#if openReqSnapshot.parents.length > 0}
                                 <span class="cursor-default select-text">
-                                    {openReqSnapshot.parentNames[0]}
+                                    {openReqSnapshot.parents[0]}
                                 </span>
                                 <ChevronRightIcon size={12} class="mx-0.5" />
 
@@ -224,7 +224,7 @@
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/if}
 
-                                {#each openReqSnapshot.parentNames.slice(parentsOverflow ? -1 : 1) as parentName, idx (idx)}
+                                {#each openReqSnapshot.parents.slice(parentsOverflow ? -1 : 1) as parentName, idx (idx)}
                                     <span class="cursor-default select-text">{parentName}</span>
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/each}

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -14,12 +14,12 @@
     import { ResponsePane } from "$lib/components/response-pane";
     import { cn } from "$lib/utils/style";
     import { explorerState, debounced, sharedState, baseRequestHeaders } from "$lib/state.svelte";
-    import { pathJoin } from "$lib/components/tree-node/utils.svelte";
     import { REQUEST_BODY_TYPES } from "$lib/utils/constants";
     import { commands } from "$lib/bindings";
     import type { HttpReq, ReqUrl } from "$lib/bindings";
     import { ChevronRightIcon, EllipsisIcon } from "@lucide/svelte";
     import { emitCmdError } from "$lib/utils";
+    import { Path } from "$lib/utils/path";
 
     let leftPane: PaneAPI | undefined = $state();
     let isLeftPaneCollapsed = $state(false);
@@ -120,12 +120,11 @@
         if ((event.metaKey || event.ctrlKey) && event.key === "s") {
             event.preventDefault();
 
-            const absoluteReqPath = pathJoin([
-                spaceSnapshot.abspath,
+            const absoluteReqPath = Path.from(spaceSnapshot.abspath).join(
                 openReqSnapshot.self.meta.relpath,
-            ]);
+            );
 
-            await debounced.flush(absoluteReqPath);
+            await debounced.flush(absoluteReqPath.toString());
             const writeReqbufToReqtomlResult = await commands.writeReqbufToReqtoml(
                 spaceSnapshot.abspath,
                 openReqSnapshot.self.meta.relpath,
@@ -208,23 +207,23 @@
             <ResizableHandle withHandle class="absolute z-10 h-full" />
             {@const openReqSnapshot = explorerState.openRequest}
             {#if openReqSnapshot}
-                {@const MAX_PARENTS_TO_SHOW = 2}
-                {@const parentsOverflow = openReqSnapshot.parents.length > MAX_PARENTS_TO_SHOW}
+                {@const MAX_TRAIL_TO_SHOW = 2}
+                {@const trailOverflow = openReqSnapshot.trail.length > MAX_TRAIL_TO_SHOW}
                 <ResizablePaneGroup direction="vertical" class="size-full">
                     <div class="p-3">
                         <div class="mb-3 flex items-center gap-0.5">
-                            {#if openReqSnapshot.parents.length > 0}
+                            {#if openReqSnapshot.trail.length > 0}
                                 <span class="cursor-default select-text">
-                                    {openReqSnapshot.parents[0]}
+                                    {openReqSnapshot.trail[0]}
                                 </span>
                                 <ChevronRightIcon size={12} class="mx-0.5" />
 
-                                {#if parentsOverflow}
+                                {#if trailOverflow}
                                     <EllipsisIcon size={12} />
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/if}
 
-                                {#each openReqSnapshot.parents.slice(parentsOverflow ? -1 : 1) as parentName, idx (idx)}
+                                {#each openReqSnapshot.trail.slice(trailOverflow ? -1 : 1) as parentName, idx (idx)}
                                     <span class="cursor-default select-text">{parentName}</span>
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/each}

--- a/src/routes/space/+page.svelte
+++ b/src/routes/space/+page.svelte
@@ -224,8 +224,8 @@
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/if}
 
-                                {#each openReqSnapshot.trail.slice(trailOverflow ? -1 : 1) as parentName, idx (idx)}
-                                    <span class="cursor-default select-text">{parentName}</span>
+                                {#each openReqSnapshot.trail.slice(trailOverflow ? -1 : 1) as trail, idx (idx)}
+                                    <span class="cursor-default select-text">{trail}</span>
                                     <ChevronRightIcon size={12} class="mx-0.5" />
                                 {/each}
                             {/if}


### PR DESCRIPTION
- replace String/&str with PathBuf for all path related variables/args
- add Path class to handle path operations on client side
- fix test cases to use proper path construction patterns
- simplify drag/drop checks
- renames and minor fixes