### PR TITLE
refactor: streamline store APIs with centralized datadir handling

### DIFF
--- a/src-tauri/src/collection/mod.rs
+++ b/src-tauri/src/collection/mod.rs
@@ -12,19 +12,16 @@ pub mod models;
 pub mod tests;
 
 use crate::{
-    collection::models::{
-        Collection, CollectionMeta, CollectionRcRefCell, CreateNewCollection,
-        SpaceCollectionsMetadataStore,
-    },
+    collection::models::{Collection, CollectionMeta, CollectionRcRefCell, CreateNewCollection},
     error::{Error, Result},
     models::SanitizedSegment,
     request::{self, models::HttpReq},
     space::parse_spacecfg,
-    store::{self, SpaceBufferStore, StateStore},
+    store::{SpaceBufferStore, collection::SpaceCollectionsMetadataStore},
     utils,
 };
 
-pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> Result<Collection> {
+pub fn parse_root_collection(space_abspath: &Path) -> Result<Collection> {
     let space_dirname = space_abspath
         .file_name()
         .unwrap_or(space_abspath.as_os_str())
@@ -33,9 +30,7 @@ pub fn parse_root_collection(space_abspath: &Path, state_store: &StateStore) -> 
     let spaceroot_relpath = PathBuf::from("");
     let scmt_store = SpaceCollectionsMetadataStore::get(space_abspath)?;
 
-    let sbf_store_abspath =
-        store::utils::sbf_store_abspath(state_store.datadir_abspath(), space_abspath);
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath)?;
+    let sbf_store = SpaceBufferStore::get(space_abspath)?;
     let sbf_store_mtx = sbf_store
         .lock()
         .map_err(|_| Error::LockError("Failed to acquire mutex lock".into()))?;

--- a/src-tauri/src/collection/models.rs
+++ b/src-tauri/src/collection/models.rs
@@ -1,16 +1,9 @@
-use std::{
-    cell::RefCell,
-    collections::BTreeMap,
-    fs,
-    ops::Deref,
-    path::{Path, PathBuf},
-    rc::Rc,
-};
+use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use crate::{error::Result, request::models::HttpReq, store};
+use crate::request::models::HttpReq;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
 pub struct CollectionMeta {
@@ -44,92 +37,4 @@ pub struct CollectionRcRefCell {
     pub meta: CollectionMeta,
     pub requests: Vec<HttpReq>,
     pub collections: Vec<Rc<RefCell<CollectionRcRefCell>>>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SpaceCollectionsMetadata {
-    pub mappings: BTreeMap<PathBuf, String>,
-}
-
-#[derive(Debug)]
-pub struct SpaceCollectionsMetadataStore {
-    metadata: SpaceCollectionsMetadata,
-    abspath: PathBuf,
-}
-
-impl Deref for SpaceCollectionsMetadataStore {
-    type Target = SpaceCollectionsMetadata;
-
-    fn deref(&self) -> &Self::Target {
-        &self.metadata
-    }
-}
-
-impl SpaceCollectionsMetadataStore {
-    fn new(space_abspath: &Path) -> Self {
-        let file_abspath = store::utils::scmt_store_abspath(space_abspath);
-
-        Self {
-            metadata: SpaceCollectionsMetadata {
-                mappings: BTreeMap::new(),
-            },
-            abspath: file_abspath,
-        }
-    }
-
-    fn init(space_abspath: &Path) -> Result<Self> {
-        let file_abspath = store::utils::scmt_store_abspath(space_abspath);
-        if !file_abspath.exists() {
-            let store = Self::new(space_abspath);
-            store.fswrite()?;
-
-            return Ok(store);
-        }
-
-        let content = fs::read_to_string(&file_abspath)?;
-
-        match toml::from_str::<SpaceCollectionsMetadata>(&content) {
-            Ok(metadata) => Ok(Self {
-                metadata,
-                abspath: file_abspath,
-            }),
-            Err(_) => {
-                // corrupt JSON, use default
-                let store = Self::new(space_abspath);
-                store.fswrite()?;
-
-                Ok(store)
-            }
-        }
-    }
-
-    fn fswrite(&self) -> Result<()> {
-        if let Some(parent) = self.abspath.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let toml_content = toml::to_string_pretty(&self.metadata)?;
-        fs::write(&self.abspath, toml_content)?;
-
-        Ok(())
-    }
-
-    pub fn get(space_abspath: &Path) -> Result<Self> {
-        Self::init(space_abspath)
-    }
-
-    /// Updates the store using the provided mutator function and
-    /// persists changes to the filesystem
-    pub fn update<F>(&mut self, mutator: F) -> Result<()>
-    where
-        F: FnOnce(&mut SpaceCollectionsMetadata),
-    {
-        mutator(&mut self.metadata);
-        self.fswrite()
-    }
-
-    /// Consumes the store and returns the inner `SpaceCollectionsMetadata`
-    pub fn into_inner(self) -> SpaceCollectionsMetadata {
-        self.metadata
-    }
 }

--- a/src-tauri/src/collection/tests.rs
+++ b/src-tauri/src/collection/tests.rs
@@ -5,14 +5,14 @@ use std::{
 };
 
 use crate::{
-    collection::{
-        self,
-        models::{CreateCollectionDto, SpaceCollectionsMetadata, SpaceCollectionsMetadataStore},
-    },
+    collection::{self, models::CreateCollectionDto},
     error::Error,
     models::SanitizedSegment,
     request::{self, models::CreateRequestDto},
-    store::{self},
+    store::{
+        self,
+        collection::{SpaceCollectionsMetadata, SpaceCollectionsMetadataStore},
+    },
     utils,
 };
 
@@ -192,7 +192,7 @@ fn parse_root_collection_should_match_created_structure() {
             .expect("Failed to create request");
     }
 
-    let root_collection = collection::parse_root_collection(&tmp_space_abspath, &state_store)
+    let root_collection = collection::parse_root_collection(&tmp_space_abspath)
         .expect("Failed to parse root collection");
 
     let mut stack = vec![(&root_collection, String::new())];

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,5 @@
 use cookie::Cookie as RawCookie;
-use dirs;
-use std::{collections::HashMap, path::PathBuf, sync::OnceLock, time::Instant};
+use std::{collections::HashMap, path::PathBuf, time::Instant};
 use tauri::Manager;
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_notification::{NotificationExt, PermissionState};
@@ -22,7 +21,7 @@ use crate::{
         models::{CreateSpaceDto, RemoveCookieDto, SerializedCookie, SpaceReference},
     },
     store::{
-        self, ReqBuffer, SpaceCookieStore, SpaceSettings, StateStore,
+        ReqBuffer, SpaceCookieStore, SpaceSettings, StateStore,
         spaces::{buffer::SpaceBufferStore, settings::SpaceSettingsStore},
         state::SharedState,
     },
@@ -30,19 +29,6 @@ use crate::{
 };
 
 pub mod models;
-
-static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
-
-/// Returns the absolute path to the application's data directory.
-pub fn datadir_abspath() -> PathBuf {
-    DATA_DIR
-        .get_or_init(|| {
-            dirs::data_dir()
-                .expect("Unable to get data directory")
-                .join("Zaku")
-        })
-        .clone()
-}
 
 pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
     tauri_specta::collect_commands![
@@ -71,8 +57,7 @@ pub fn collect() -> tauri_specta::Commands<tauri::Wry> {
 #[specta::specta]
 #[tauri::command]
 pub fn get_shared_state() -> CmdResult<SharedState> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let state_store = StateStore::get(&state_store_abspath).map_err(|err| CmdErr {
+    let state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(err.to_string()),
@@ -90,8 +75,7 @@ pub fn get_shared_state() -> CmdResult<SharedState> {
 #[specta::specta]
 #[tauri::command]
 pub async fn create_collection(dto: CreateCollectionDto) -> CmdResult<CreateNewCollection> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let state_store = StateStore::get(&state_store_abspath).map_err(|err| CmdErr {
+    let state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(err.to_string()),
@@ -213,8 +197,7 @@ pub fn dispatch_notif(
 #[specta::specta]
 #[tauri::command]
 pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let state_store = StateStore::get(&state_store_abspath).map_err(|err| CmdErr {
+    let state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(err.to_string()),
@@ -252,8 +235,7 @@ pub async fn create_req(dto: CreateRequestDto) -> CmdResult<CreateNewRequest> {
 #[specta::specta]
 #[tauri::command]
 pub async fn write_req_to_space_buffer(space_abspath: PathBuf, request: HttpReq) -> CmdResult<()> {
-    let sbf_store_abspath = store::utils::sbf_store_abspath(&datadir_abspath(), &space_abspath);
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).map_err(|err| CmdErr {
+    let sbf_store = SpaceBufferStore::get(&space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space buffer".to_string(),
         details: Some(err.to_string()),
@@ -284,8 +266,7 @@ pub async fn write_reqbuf_to_reqtoml(
     req_relpath: PathBuf,
 ) -> CmdResult<()> {
     let space_abspath = &space_abspath;
-    let sbf_store_abspath = store::utils::sbf_store_abspath(&datadir_abspath(), space_abspath);
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).map_err(|err| CmdErr {
+    let sbf_store = SpaceBufferStore::get(space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space buffer".to_string(),
         details: Some(err.to_string()),
@@ -313,8 +294,7 @@ pub async fn write_reqbuf_to_reqtoml(
 #[specta::specta]
 #[tauri::command]
 pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<HttpRes> {
-    let store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let state_store = StateStore::get(&store_abspath).map_err(|err| CmdErr {
+    let state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load store".to_string(),
         details: Some(err.to_string()),
@@ -326,15 +306,13 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
         details: None,
     })?;
 
-    let sck_store_abspath = store::utils::sck_store_abspath(&datadir_abspath(), &spaceref.abspath);
-    let mut sck_store = SpaceCookieStore::get(&sck_store_abspath).map_err(|err| CmdErr {
+    let mut sck_store = SpaceCookieStore::get(&spaceref.abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load cookies".to_string(),
         details: Some(err.to_string()),
     })?;
 
-    let sst_store_abspath = store::utils::sst_store_abspath(&datadir_abspath(), &spaceref.abspath);
-    let sst_store = SpaceSettingsStore::get(&sst_store_abspath).map_err(|err| CmdErr {
+    let sst_store = SpaceSettingsStore::get(&spaceref.abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space settings".to_string(),
         details: Some(err.to_string()),
@@ -443,8 +421,7 @@ pub async fn http_req(req: HttpReq, app_handle: tauri::AppHandle) -> CmdResult<H
 #[specta::specta]
 #[tauri::command]
 pub async fn create_space(create_space_dto: CreateSpaceDto) -> CmdResult<SpaceReference> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let mut state_store = StateStore::get(&state_store_abspath).map_err(|err| CmdErr {
+    let mut state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(err.to_string()),
@@ -472,14 +449,13 @@ pub fn set_space(space_reference: SpaceReference) -> CmdResult<()> {
         });
     }
 
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let mut state_store = StateStore::get(&state_store_abspath).map_err(|e| CmdErr {
+    let mut state_store = StateStore::get().map_err(|e| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store for validation".to_string(),
         details: Some(e.to_string()),
     })?;
 
-    space::parse_space(space_abspath, &state_store).map_err(|err| CmdErr {
+    space::parse_space(space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::ParseError,
         message: "Unable to load space".to_string(),
         details: Some(err.to_string()),
@@ -510,8 +486,7 @@ pub fn set_space(space_reference: SpaceReference) -> CmdResult<()> {
 #[specta::specta]
 #[tauri::command]
 pub fn remove_space(space_reference: SpaceReference) -> CmdResult<()> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let mut state_store = StateStore::get(&state_store_abspath).map_err(|e| CmdErr {
+    let mut state_store = StateStore::get().map_err(|e| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(e.to_string()),
@@ -579,8 +554,7 @@ pub fn get_spaceref(path: PathBuf) -> CmdResult<SpaceReference> {
 pub async fn get_space_cookies(
     space_abspath: PathBuf,
 ) -> CmdResult<HashMap<String, Vec<SerializedCookie>>> {
-    let sck_store_abspath = store::utils::sck_store_abspath(&datadir_abspath(), &space_abspath);
-    let sck_store = SpaceCookieStore::get(&sck_store_abspath).map_err(|e| CmdErr {
+    let sck_store = SpaceCookieStore::get(&space_abspath).map_err(|e| CmdErr {
         kind: ErrorKind::CookieError,
         message: "Unable to load cookies".to_string(),
         details: Some(e.to_string()),
@@ -616,8 +590,7 @@ pub async fn get_space_cookies(
 pub fn remove_cookie(space_abspath: PathBuf, rm_cookie_dto: RemoveCookieDto) -> CmdResult<bool> {
     let RemoveCookieDto { domain, path, name } = rm_cookie_dto;
 
-    let sck_store_abspath = store::utils::sck_store_abspath(&datadir_abspath(), &space_abspath);
-    let mut sck_store = SpaceCookieStore::get(&sck_store_abspath).map_err(|e| CmdErr {
+    let mut sck_store = SpaceCookieStore::get(&space_abspath).map_err(|e| CmdErr {
         kind: ErrorKind::CookieError,
         message: "Unable to load cookies".to_string(),
         details: Some(e.to_string()),
@@ -642,8 +615,7 @@ pub async fn save_space_settings(
     space_abspath: PathBuf,
     space_settings: SpaceSettings,
 ) -> CmdResult<()> {
-    let sst_store_abspath = store::utils::sst_store_abspath(&datadir_abspath(), &space_abspath);
-    let mut sst_store = SpaceSettingsStore::get(&sst_store_abspath).map_err(|err| CmdErr {
+    let mut sst_store = SpaceSettingsStore::get(&space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load space settings".to_string(),
         details: Some(err.to_string()),
@@ -673,8 +645,7 @@ pub fn show_main_window(window: tauri::Window) -> CmdResult<()> {
 #[specta::specta]
 #[tauri::command]
 pub async fn move_tree_node(dto: MoveTreeNodeDto) -> CmdResult<()> {
-    let state_store_abspath = store::utils::state_store_abspath(&datadir_abspath());
-    let state_store = StateStore::get(&state_store_abspath).map_err(|err| CmdErr {
+    let state_store = StateStore::get().map_err(|err| CmdErr {
         kind: ErrorKind::FileReadError,
         message: "Unable to load state store".to_string(),
         details: Some(err.to_string()),
@@ -691,7 +662,7 @@ pub async fn move_tree_node(dto: MoveTreeNodeDto) -> CmdResult<()> {
         .abspath
         .clone();
 
-    tree_node::move_tree_node(&dto, &space_abspath, &state_store).map_err(|err| CmdErr {
+    tree_node::move_tree_node(&dto, &space_abspath).map_err(|err| CmdErr {
         kind: ErrorKind::FileWriteError,
         message: format!("Unable to move the {}", dto.node_type),
         details: Some(err.to_string()),

--- a/src-tauri/src/request/tests.rs
+++ b/src-tauri/src/request/tests.rs
@@ -16,13 +16,13 @@ use crate::{
 
 #[test]
 fn parse_req_returns_none_for_non_toml_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let txt_file_abspath = tmp_space_abspath.join("parent-req-1.txt");
     fs::write(&txt_file_abspath, "not a toml file").unwrap();
 
-    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_dir.path(), tmp_space_abspath);
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store
         .lock()
@@ -35,13 +35,13 @@ fn parse_req_returns_none_for_non_toml_file() {
 
 #[test]
 fn parse_req_returns_none_for_directory() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let dir_abspath = tmp_space_abspath.join("parent-col-1");
     fs::create_dir_all(&dir_abspath).unwrap();
 
-    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_dir.path(), tmp_space_abspath);
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store
         .lock()
@@ -54,13 +54,13 @@ fn parse_req_returns_none_for_directory() {
 
 #[test]
 fn parse_req_successfully_parses_valid_toml_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let reqfile_abspath = tmp_space_abspath.join("parent-req-1");
     request::create_reqtoml(&reqfile_abspath, "Parent Req 1").unwrap();
 
-    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_dir.path(), tmp_space_abspath);
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store
         .lock()
@@ -79,14 +79,14 @@ fn parse_req_successfully_parses_valid_toml_file() {
 
 #[test]
 fn parse_req_returns_none_for_invalid_toml() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let reqfile_abspath = tmp_space_abspath.join("invalid-req-1.toml");
     let invalid_toml = "[meta\nname = \"Invalid Req 1\"";
     fs::write(&reqfile_abspath, invalid_toml).unwrap();
 
-    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_dir.path(), tmp_space_abspath);
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     let sbf_store_mtx = sbf_store
         .lock()
@@ -99,13 +99,13 @@ fn parse_req_returns_none_for_invalid_toml() {
 
 #[test]
 fn parse_req_returns_buffered_request_when_available() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let reqfile_abspath = tmp_space_abspath.join("buffered-req-1.toml");
     request::create_reqtoml(&reqfile_abspath.with_extension(""), "Buffered Req 1").unwrap();
 
-    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_dir.path(), tmp_space_abspath);
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
     {
         let mut sbf_store_mtx = sbf_store
@@ -276,8 +276,8 @@ fn create_req_missing_space_should_fail() {
         fsname: "child-req-1".to_string(),
     };
 
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let tmp_space_abspath = tmp_dir.path();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
     let result = request::create_req(
         &PathBuf::from("parent-col-1"),
         &req_segment,
@@ -413,8 +413,8 @@ fn create_req_duplicate_name_should_fail() {
 
 #[test]
 fn create_reqtoml_creates_valid_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("child-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("child-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Child Req 1").expect("Failed to create TOML file");
 
@@ -433,8 +433,8 @@ fn create_reqtoml_creates_valid_file() {
 
 #[test]
 fn create_reqtoml_skips_serializing_empty_optional_fields() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("empty-fields-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("empty-fields-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Empty Fields Req 1")
         .expect("Failed to create TOML file");
@@ -451,8 +451,8 @@ fn create_reqtoml_skips_serializing_empty_optional_fields() {
 
 #[test]
 fn create_reqtoml_with_special_characters_in_name() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("special-chars-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("special-chars-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Special*Chars<>|Req 1")
         .expect("Failed to create TOML file");
@@ -464,8 +464,8 @@ fn create_reqtoml_with_special_characters_in_name() {
 
 #[test]
 fn create_reqtoml_with_unicode_name() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("unicode-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("unicode-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "ザク Unicode Req 1")
         .expect("Failed to create TOML file");
@@ -477,8 +477,8 @@ fn create_reqtoml_with_unicode_name() {
 
 #[test]
 fn parse_reqtoml_successfully_parses_valid_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("parent-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("parent-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Parent Req 1").expect("Failed to create TOML");
 
@@ -491,8 +491,8 @@ fn parse_reqtoml_successfully_parses_valid_file() {
 
 #[test]
 fn parse_reqtoml_with_custom_config() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("custom-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("custom-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Custom Req 1").expect("Failed to create TOML");
 
@@ -524,8 +524,8 @@ fn parse_reqtoml_with_custom_config() {
 
 #[test]
 fn parse_reqtoml_fails_for_invalid_toml() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("invalid-req-1.toml");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("invalid-req-1.toml");
 
     let invalid_toml = "[meta\nname = \"Invalid Req 1\"";
     fs::write(&reqfile_abspath, invalid_toml).unwrap();
@@ -536,8 +536,8 @@ fn parse_reqtoml_fails_for_invalid_toml() {
 
 #[test]
 fn parse_reqtoml_fails_for_nonexistent_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let nonexistent_reqfile_abspath = tmp_dir.path().join("nonexistent-req-1.toml");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let nonexistent_reqfile_abspath = tmp_spacedir.path().join("nonexistent-req-1.toml");
 
     let result = request::parse_reqtoml(&nonexistent_reqfile_abspath);
     assert!(result.is_err());
@@ -545,8 +545,8 @@ fn parse_reqtoml_fails_for_nonexistent_file() {
 
 #[test]
 fn update_reqtoml_successfully_updates_existing_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("update-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("update-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Update Req 1").unwrap();
     let toml_file = reqfile_abspath.with_extension("toml");
@@ -579,8 +579,8 @@ fn update_reqtoml_successfully_updates_existing_file() {
 
 #[test]
 fn update_reqtoml_fails_for_nonexistent_file() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let nonexistent_reqfile_abspath = tmp_dir.path().join("nonexistent-req-1.toml");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let nonexistent_reqfile_abspath = tmp_spacedir.path().join("nonexistent-req-1.toml");
 
     let req_toml = ReqToml {
         meta: ReqTomlMeta {
@@ -602,8 +602,8 @@ fn update_reqtoml_fails_for_nonexistent_file() {
 
 #[test]
 fn update_reqtoml_with_headers_and_parameters() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("headers-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("headers-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Headers Req 1").unwrap();
     let toml_file = reqfile_abspath.with_extension("toml");
@@ -648,8 +648,8 @@ fn update_reqtoml_with_headers_and_parameters() {
 
 #[test]
 fn update_reqtoml_skips_serializing_empty_fields() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let reqfile_abspath = tmp_dir.path().join("empty-update-req-1");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let reqfile_abspath = tmp_spacedir.path().join("empty-update-req-1");
 
     request::create_reqtoml(&reqfile_abspath, "Empty Update Req 1").unwrap();
     let toml_file = reqfile_abspath.with_extension("toml");

--- a/src-tauri/src/space/mod.rs
+++ b/src-tauri/src/space/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     space::models::{
         CreateSpaceDto, SerializedCookie, Space, SpaceConfigFile, SpaceMeta, SpaceReference,
     },
-    store::{self, SpaceCookieStore, SpaceSettingsStore, StateStore},
+    store::{SpaceCookieStore, SpaceSettingsStore, StateStore},
     utils,
 };
 
@@ -71,13 +71,11 @@ pub fn create_space(dto: CreateSpaceDto, state_store: &mut StateStore) -> Result
     Ok(spaceref)
 }
 
-pub fn parse_space(space_abspath: &Path, state_store: &StateStore) -> Result<Space> {
-    let root_collection = collection::parse_root_collection(space_abspath, state_store)?;
+pub fn parse_space(space_abspath: &Path) -> Result<Space> {
+    let root_collection = collection::parse_root_collection(space_abspath)?;
     let space_config_file = parse_spacecfg(space_abspath)?;
 
-    let sck_store_abspath =
-        store::utils::sck_store_abspath(state_store.datadir_abspath(), space_abspath);
-    let sck_store = SpaceCookieStore::get(&sck_store_abspath)?;
+    let sck_store = SpaceCookieStore::get(space_abspath)?;
     let sck_store_mtx = sck_store.cookies.lock().unwrap();
     let cookies: Vec<SerializedCookie> = sck_store_mtx
         .iter_any()
@@ -89,9 +87,7 @@ pub fn parse_space(space_abspath: &Path, state_store: &StateStore) -> Result<Spa
             acc
         });
 
-    let sst_store_abspath =
-        store::utils::sst_store_abspath(state_store.datadir_abspath(), space_abspath);
-    let space_settings = SpaceSettingsStore::get(&sst_store_abspath)?.into_inner();
+    let space_settings = SpaceSettingsStore::get(space_abspath)?.into_inner();
 
     Ok(Space {
         abspath: space_abspath.to_path_buf(),

--- a/src-tauri/src/store/collection.rs
+++ b/src-tauri/src/store/collection.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fs,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+use crate::{error::Result, store};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SpaceCollectionsMetadata {
+    pub mappings: BTreeMap<PathBuf, String>,
+}
+
+#[derive(Debug)]
+pub struct SpaceCollectionsMetadataStore {
+    metadata: SpaceCollectionsMetadata,
+    abspath: PathBuf,
+}
+
+impl Deref for SpaceCollectionsMetadataStore {
+    type Target = SpaceCollectionsMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metadata
+    }
+}
+
+impl SpaceCollectionsMetadataStore {
+    fn new(space_abspath: &Path) -> Self {
+        let file_abspath = store::utils::scmt_store_abspath(space_abspath);
+
+        Self {
+            metadata: SpaceCollectionsMetadata {
+                mappings: BTreeMap::new(),
+            },
+            abspath: file_abspath,
+        }
+    }
+
+    fn init(space_abspath: &Path) -> Result<Self> {
+        let file_abspath = store::utils::scmt_store_abspath(space_abspath);
+        if !file_abspath.exists() {
+            let store = Self::new(space_abspath);
+            store.fswrite()?;
+
+            return Ok(store);
+        }
+
+        let content = fs::read_to_string(&file_abspath)?;
+
+        match toml::from_str::<SpaceCollectionsMetadata>(&content) {
+            Ok(metadata) => Ok(Self {
+                metadata,
+                abspath: file_abspath,
+            }),
+            Err(_) => {
+                // corrupt JSON, use default
+                let store = Self::new(space_abspath);
+                store.fswrite()?;
+
+                Ok(store)
+            }
+        }
+    }
+
+    fn fswrite(&self) -> Result<()> {
+        if let Some(parent) = self.abspath.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let toml_content = toml::to_string_pretty(&self.metadata)?;
+        fs::write(&self.abspath, toml_content)?;
+
+        Ok(())
+    }
+
+    pub fn get(space_abspath: &Path) -> Result<Self> {
+        Self::init(space_abspath)
+    }
+
+    /// Updates the store using the provided mutator function and
+    /// persists changes to the filesystem
+    pub fn update<F>(&mut self, mutator: F) -> Result<()>
+    where
+        F: FnOnce(&mut SpaceCollectionsMetadata),
+    {
+        mutator(&mut self.metadata);
+        self.fswrite()
+    }
+
+    /// Consumes the store and returns the inner `SpaceCollectionsMetadata`
+    pub fn into_inner(self) -> SpaceCollectionsMetadata {
+        self.metadata
+    }
+}

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -1,3 +1,4 @@
+pub mod collection;
 pub mod spaces;
 pub mod state;
 pub mod utils;

--- a/src-tauri/src/store/spaces/buffer.rs
+++ b/src-tauri/src/store/spaces/buffer.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use specta::Type;
 use std::{
     collections::HashMap,
     fs,
@@ -11,12 +10,12 @@ use std::{
 use crate::{
     error::{Error, Result},
     request::models::HttpReq,
-    utils,
+    store, utils,
 };
 
 static SBF_STORE_UPDATE_LOCK: Mutex<()> = Mutex::new(());
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, Type)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpaceBuffer {
     pub requests: HashMap<PathBuf, ReqBuffer>,
 }
@@ -42,34 +41,38 @@ impl DerefMut for SpaceBufferStore {
 }
 
 impl SpaceBufferStore {
-    fn new(sbf_store_abspath: &Path) -> Self {
+    fn new(space_abspath: &Path) -> Self {
+        let sbf_store_abspath = store::utils::sbf_store_abspath(space_abspath);
+
         Self {
             buffer: SpaceBuffer {
                 requests: HashMap::<PathBuf, ReqBuffer>::new(),
             },
-            abspath: sbf_store_abspath.to_path_buf(),
+            abspath: sbf_store_abspath,
         }
     }
 
-    fn init(sbf_store_abspath: &Path) -> Result<Arc<Mutex<SpaceBufferStore>>> {
+    fn init(space_abspath: &Path) -> Result<Arc<Mutex<SpaceBufferStore>>> {
+        let sbf_store_abspath = store::utils::sbf_store_abspath(space_abspath);
+
         if !sbf_store_abspath.exists() {
-            let default_buffer = Arc::new(Mutex::new(Self::new(sbf_store_abspath)));
+            let default_buffer = Arc::new(Mutex::new(Self::new(space_abspath)));
             Self::fswrite(&default_buffer)?;
 
             return Ok(default_buffer);
         }
 
-        let content = fs::read_to_string(sbf_store_abspath)
+        let content = fs::read_to_string(&sbf_store_abspath)
             .map_err(|_| Error::FileReadError("Failed to read from space buffer".into()))?;
 
         let sbf_store = match serde_json::from_str::<SpaceBuffer>(&content) {
             Ok(buffer) => Self {
                 buffer,
-                abspath: sbf_store_abspath.to_path_buf(),
+                abspath: sbf_store_abspath,
             },
             Err(_) => {
                 // corrupt JSON, use default
-                let default_buffer = Self::new(sbf_store_abspath);
+                let default_buffer = Self::new(space_abspath);
                 let buffer_arc = Arc::new(Mutex::new(default_buffer));
                 Self::fswrite(&buffer_arc)?;
 
@@ -95,8 +98,8 @@ impl SpaceBufferStore {
         Ok(())
     }
 
-    pub fn get(sbf_store_abspath: &Path) -> Result<Arc<Mutex<SpaceBufferStore>>> {
-        Self::init(sbf_store_abspath)
+    pub fn get(space_abspath: &Path) -> Result<Arc<Mutex<SpaceBufferStore>>> {
+        Self::init(space_abspath)
     }
 
     /// Updates the store using the provided mutator function and
@@ -119,13 +122,13 @@ impl SpaceBufferStore {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReqBufferMeta {
     pub fsname: String,
     pub name: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReqBufferUrl {
     #[serde(skip_serializing_if = "utils::is_string_none_or_empty")]
     pub raw: Option<String>,
@@ -140,7 +143,7 @@ pub struct ReqBufferUrl {
     pub path: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReqBufferCfg {
     pub method: String,
     pub url: ReqBufferUrl,
@@ -158,7 +161,7 @@ pub struct ReqBufferCfg {
     pub body: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReqBuffer {
     pub meta: ReqBufferMeta,
     pub config: ReqBufferCfg,

--- a/src-tauri/src/store/spaces/cookie.rs
+++ b/src-tauri/src/store/spaces/cookie.rs
@@ -7,7 +7,10 @@ use std::{
     sync::Arc,
 };
 
-use crate::error::{Error, Result};
+use crate::{
+    error::{Error, Result},
+    store,
+};
 
 pub struct SpaceCookieStore {
     pub cookies: Arc<CookieStoreMutex>,
@@ -15,34 +18,38 @@ pub struct SpaceCookieStore {
 }
 
 impl SpaceCookieStore {
-    fn new(sck_store_abspath: &Path, cookies: Arc<CookieStoreMutex>) -> Self {
+    fn new(space_abspath: &Path, cookies: Arc<CookieStoreMutex>) -> Self {
+        let sck_store_abspath = store::utils::sck_store_abspath(space_abspath);
+
         Self {
             cookies,
-            abspath: sck_store_abspath.to_path_buf(),
+            abspath: sck_store_abspath,
         }
     }
 
-    fn init(sck_store_abspath: &Path) -> Result<SpaceCookieStore> {
+    fn init(space_abspath: &Path) -> Result<SpaceCookieStore> {
+        let sck_store_abspath = store::utils::sck_store_abspath(space_abspath);
+
         if !sck_store_abspath.exists() {
             let default_cookies = Arc::new(CookieStoreMutex::new(CookieStore::default()));
-            let sck_store = Self::new(sck_store_abspath, default_cookies);
+            let sck_store = Self::new(space_abspath, default_cookies);
             sck_store.fswrite()?;
 
             return Ok(sck_store);
         }
 
-        let file = fs::File::open(sck_store_abspath).map(BufReader::new)?;
+        let file = fs::File::open(&sck_store_abspath).map(BufReader::new)?;
 
         match cookie_json::load(file) {
             Ok(cookie_store) => {
                 let cookies = Arc::new(CookieStoreMutex::new(cookie_store));
 
-                Ok(Self::new(sck_store_abspath, cookies))
+                Ok(Self::new(space_abspath, cookies))
             }
             Err(_) => {
                 // corrupt JSON, use default
                 let default_cookies = Arc::new(CookieStoreMutex::new(CookieStore::default()));
-                let sck_store = Self::new(sck_store_abspath, default_cookies);
+                let sck_store = Self::new(space_abspath, default_cookies);
                 sck_store.fswrite()?;
 
                 Ok(sck_store)
@@ -66,8 +73,8 @@ impl SpaceCookieStore {
         Ok(())
     }
 
-    pub fn get(sck_store_abspath: &Path) -> Result<SpaceCookieStore> {
-        Self::init(sck_store_abspath)
+    pub fn get(space_abspath: &Path) -> Result<SpaceCookieStore> {
+        Self::init(space_abspath)
     }
 
     /// Updates the store using the provided mutator function and

--- a/src-tauri/src/store/spaces/settings.rs
+++ b/src-tauri/src/store/spaces/settings.rs
@@ -42,15 +42,9 @@ impl Deref for SpaceSettingsStore {
 }
 
 impl SpaceSettingsStore {
-    fn new(sst_store_abspath: &Path) -> Self {
-        let datadir_abspath = sst_store_abspath
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .expect("Invalid spacesettings path structure");
-
-        let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-        let state_store = StateStore::get(&state_store_abspath).expect("Failed to get StateStore");
+    fn new(space_abspath: &Path) -> Self {
+        let state_store = StateStore::get().expect("Failed to get StateStore");
+        let sst_store_abspath = store::utils::sst_store_abspath(space_abspath);
 
         Self {
             settings: SpaceSettings {
@@ -61,28 +55,30 @@ impl SpaceSettingsStore {
                     },
                 },
             },
-            abspath: sst_store_abspath.to_path_buf(),
+            abspath: sst_store_abspath,
         }
     }
 
-    fn init(sst_store_abspath: &Path) -> Result<Self> {
+    fn init(space_abspath: &Path) -> Result<Self> {
+        let sst_store_abspath = store::utils::sst_store_abspath(space_abspath);
+
         if !sst_store_abspath.exists() {
-            let sst_store = Self::new(sst_store_abspath);
+            let sst_store = Self::new(space_abspath);
             sst_store.fswrite()?;
 
             return Ok(sst_store);
         }
 
-        let file_content = fs::read_to_string(sst_store_abspath)?;
+        let file_content = fs::read_to_string(&sst_store_abspath)?;
 
         match serde_json::from_str::<SpaceSettings>(&file_content) {
             Ok(space_settings) => Ok(Self {
                 settings: space_settings,
-                abspath: sst_store_abspath.to_path_buf(),
+                abspath: sst_store_abspath,
             }),
             Err(_) => {
                 // corrupt JSON, use default
-                let sst_store = Self::new(sst_store_abspath);
+                let sst_store = Self::new(space_abspath);
                 sst_store.fswrite()?;
 
                 Ok(sst_store)
@@ -101,8 +97,8 @@ impl SpaceSettingsStore {
         Ok(())
     }
 
-    pub fn get(sst_store_abspath: &Path) -> Result<SpaceSettingsStore> {
-        Self::init(sst_store_abspath)
+    pub fn get(space_abspath: &Path) -> Result<SpaceSettingsStore> {
+        Self::init(space_abspath)
     }
 
     /// Updates the store using the provided mutator function and

--- a/src-tauri/src/store/state.rs
+++ b/src-tauri/src/store/state.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::{
-    fs,
-    ops::Deref,
-    path::{Path, PathBuf},
-};
+use std::{fs, ops::Deref, path::PathBuf};
 
 use crate::{
     error::Result,
@@ -12,6 +8,7 @@ use crate::{
         self,
         models::{Space, SpaceReference},
     },
+    store,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Type)]
@@ -36,7 +33,7 @@ pub struct SharedState {
 impl SharedState {
     pub fn from_state_store(state_store: &StateStore) -> Result<Self> {
         let parsed_space = match &state_store.spaceref {
-            Some(spaceref) => Some(space::parse_space(&spaceref.abspath, state_store)?),
+            Some(spaceref) => Some(space::parse_space(&spaceref.abspath)?),
             None => None,
         };
 
@@ -69,8 +66,14 @@ impl Deref for StateStore {
     }
 }
 
+impl Default for StateStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StateStore {
-    pub fn new(state_store_abspath: &Path) -> Self {
+    pub fn new() -> Self {
         Self {
             state: State {
                 spaceref: None,
@@ -79,28 +82,30 @@ impl StateStore {
                     default_theme: Theme::System,
                 },
             },
-            abspath: state_store_abspath.to_path_buf(),
+            abspath: store::utils::state_store_abspath(),
         }
     }
 
-    fn init(state_store_abspath: &Path) -> Result<StateStore> {
+    fn init() -> Result<StateStore> {
+        let state_store_abspath = store::utils::state_store_abspath();
+
         if !state_store_abspath.exists() {
-            let default_store = Self::new(state_store_abspath);
+            let default_store = Self::new();
             default_store.fswrite()?;
 
             return Ok(default_store);
         }
 
-        let state_content = fs::read_to_string(state_store_abspath)?;
+        let state_content = fs::read_to_string(&state_store_abspath)?;
 
         match serde_json::from_str::<State>(&state_content) {
             Ok(state) => Ok(Self {
                 state,
-                abspath: state_store_abspath.to_path_buf(),
+                abspath: state_store_abspath,
             }),
             Err(_) => {
                 // corrupt JSON, use default
-                let default_store = Self::new(state_store_abspath);
+                let default_store = Self::new();
                 default_store.fswrite()?;
 
                 Ok(default_store)
@@ -119,8 +124,8 @@ impl StateStore {
         Ok(())
     }
 
-    pub fn get(state_store_abspath: &Path) -> Result<StateStore> {
-        Self::init(state_store_abspath)
+    pub fn get() -> Result<StateStore> {
+        Self::init()
     }
 
     /// Updates the store using the provided mutator function and
@@ -136,12 +141,5 @@ impl StateStore {
     /// Consumes the store and returns the inner `State`
     pub fn into_inner(self) -> State {
         self.state
-    }
-
-    /// Returns the data directory, which is the parent directory of the state store file
-    pub fn datadir_abspath(&self) -> &Path {
-        self.abspath
-            .parent()
-            .expect("StateStore abspath should have a parent directory")
     }
 }

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::{path::PathBuf, sync::Arc, thread};
-use tempfile;
 
 use crate::store::spaces::buffer::{ReqBufferCfg, ReqBufferMeta, ReqBufferUrl};
 use crate::store::{self, StateStore};
@@ -10,22 +9,21 @@ use crate::{
 };
 
 #[test]
-fn state_store_get_creates_default_when_file_doesnt_exist() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let state_store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+fn state_store_creates_file_with_defaults_when_missing() {
+    let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Test Space");
+    let state_store_abspath = store::utils::state_store_abspath();
 
-    let state_store = StateStore::get(&state_store_abspath).unwrap();
-
-    assert!(state_store.spaceref.is_none());
-    assert!(state_store.spacerefs.is_empty());
+    assert!(state_store.spaceref.is_some());
+    assert_eq!(state_store.spacerefs.len(), 1);
     assert_eq!(state_store.user_settings.default_theme, Theme::System);
     assert!(state_store_abspath.exists());
 }
 
 #[test]
 fn state_store_get_loads_existing_store_from_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+    let (_tmp_datadir, _tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+
+    let store_abspath = store::utils::state_store_abspath();
 
     if let Some(parent) = store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -55,7 +53,7 @@ fn state_store_get_loads_existing_store_from_filesystem() {
     });
     fs::write(&store_abspath, json_content.to_string()).unwrap();
 
-    let loaded_state_store = StateStore::get(&store_abspath).unwrap();
+    let loaded_state_store = StateStore::get().unwrap();
 
     assert!(loaded_state_store.spaceref.is_some());
     assert_eq!(
@@ -69,19 +67,18 @@ fn state_store_get_loads_existing_store_from_filesystem() {
 
 #[test]
 fn state_store_update_persists_changes_to_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+    let (_tmp_datadir, _tmp_spacedir, _state_store) = store::utils::temp_space("Test Space 1");
 
     let space_ref_1 = SpaceReference {
-        abspath: PathBuf::from("test/space-1"),
-        name: "Test Space 1".to_string(),
-    };
-    let space_ref_2 = SpaceReference {
-        abspath: PathBuf::from("test/space-2"),
+        abspath: PathBuf::from("tmp/test-space-2"),
         name: "Test Space 2".to_string(),
     };
+    let space_ref_2 = SpaceReference {
+        abspath: PathBuf::from("tmp/test-space-3"),
+        name: "Test Space 3".to_string(),
+    };
 
-    let mut state_store = StateStore::get(&store_abspath).unwrap();
+    let mut state_store = StateStore::get().unwrap();
     state_store
         .update(|state| {
             state.spaceref = Some(space_ref_1.clone());
@@ -92,26 +89,27 @@ fn state_store_update_persists_changes_to_filesystem() {
         .unwrap();
 
     assert!(state_store.spaceref.is_some());
-    assert_eq!(state_store.spacerefs.len(), 2);
+    assert_eq!(state_store.spacerefs.len(), 3);
 
-    let fresh_state_store = StateStore::get(&store_abspath).unwrap();
+    let fresh_state_store = StateStore::get().unwrap();
     assert!(fresh_state_store.spaceref.is_some());
     assert_eq!(
         fresh_state_store.spaceref.as_ref().unwrap().abspath,
-        PathBuf::from("test").join("space-1")
+        PathBuf::from("tmp").join("test-space-2")
     );
     assert_eq!(fresh_state_store.user_settings.default_theme, Theme::Light);
-    assert_eq!(fresh_state_store.spacerefs.len(), 2);
+    assert_eq!(fresh_state_store.spacerefs.len(), 3);
 }
 
 #[test]
 fn state_store_handles_corrupt_json_by_overwriting_with_defaults() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+    let (_tmp_datadir, _tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+
+    let store_abspath = store::utils::state_store_abspath();
 
     fs::write(&store_abspath, "invalid json {").unwrap();
 
-    let state_store = StateStore::get(&store_abspath).unwrap();
+    let state_store = StateStore::get().unwrap();
     assert!(state_store.spaceref.is_none());
     assert!(state_store.spacerefs.is_empty());
 
@@ -124,8 +122,9 @@ fn state_store_handles_corrupt_json_by_overwriting_with_defaults() {
 
 #[test]
 fn state_store_get_loads_existing_settings_from_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let state_store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+    let (_tmp_datadir, _tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+
+    let state_store_abspath = store::utils::state_store_abspath();
 
     if let Some(parent) = state_store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -140,17 +139,18 @@ fn state_store_get_loads_existing_settings_from_filesystem() {
     });
     fs::write(&state_store_abspath, json_content.to_string()).unwrap();
 
-    let state_store = StateStore::get(&state_store_abspath).unwrap();
+    let state_store = StateStore::get().unwrap();
 
     assert_eq!(state_store.user_settings.default_theme, Theme::Dark);
 }
 
 #[test]
 fn state_store_handles_corrupt_json_by_using_default() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let state_store_abspath = store::utils::state_store_abspath(tmp_dir.path());
+    let (_tmp_datadir, _tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
 
-    let mut state_store = StateStore::get(&state_store_abspath).unwrap();
+    let state_store_abspath = store::utils::state_store_abspath();
+
+    let mut state_store = StateStore::get().unwrap();
     state_store
         .update(|state| {
             state.user_settings.default_theme = Theme::Dark;
@@ -159,7 +159,7 @@ fn state_store_handles_corrupt_json_by_using_default() {
 
     fs::write(&state_store_abspath, "invalid json {").unwrap();
 
-    let state_store = StateStore::get(&state_store_abspath).unwrap();
+    let state_store = StateStore::get().unwrap();
     assert_eq!(state_store.user_settings.default_theme, Theme::System);
 
     let content = fs::read_to_string(&state_store_abspath).unwrap();
@@ -168,24 +168,22 @@ fn state_store_handles_corrupt_json_by_using_default() {
 
 #[test]
 fn sbf_store_get_creates_empty_buffer_when_file_doesnt_exist() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sbf_store_abspath = store::utils::sbf_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
     let sbf_store_mtx = sbf_store.lock().unwrap();
 
     assert!(sbf_store_mtx.requests.is_empty());
+
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     assert!(sbf_store_abspath.exists());
 }
 
 #[test]
 fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sbf_store_abspath = store::utils::sbf_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let req_buf = ReqBuffer {
         meta: ReqBufferMeta {
@@ -207,7 +205,8 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
         },
     };
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
+    let sbf_store_abspath = store::utils::sbf_store_abspath(tmp_space_abspath);
     SpaceBufferStore::update(&sbf_store, |sbf_store| {
         let mut sbf_store_mtx = sbf_store.lock().unwrap();
         sbf_store_mtx
@@ -225,7 +224,7 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
             .contains_key(&PathBuf::from("test-req.toml"))
     );
 
-    let fresh_sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let fresh_sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
     let fresh_lock = fresh_sbf_store.lock().unwrap();
     assert!(
         fresh_lock
@@ -236,12 +235,10 @@ fn sbf_store_update_persists_changes_to_filesystem_and_returns_updated_buffer() 
 
 #[test]
 fn sbf_store_handles_concurrent_access_to_same_buffer_instance() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sbf_store_abspath = store::utils::sbf_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
     let sbf_store_clone = Arc::clone(&sbf_store);
 
     let handles: Vec<_> = (0..10)
@@ -292,10 +289,8 @@ fn sbf_store_handles_concurrent_access_to_same_buffer_instance() {
 
 #[test]
 fn sbf_store_maintains_persistence_across_separate_get_calls() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sbf_store_abspath = store::utils::sbf_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
     let req_buf = ReqBuffer {
         meta: ReqBufferMeta {
@@ -317,7 +312,7 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
         },
     };
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
     SpaceBufferStore::update(&sbf_store, |sbf_store| {
         let mut sbf_store_mtx = sbf_store.lock().unwrap();
         sbf_store_mtx
@@ -326,7 +321,7 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
     })
     .unwrap();
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
     let sbf_store_mtx = sbf_store.lock().unwrap();
     assert!(
         sbf_store_mtx
@@ -344,12 +339,10 @@ fn sbf_store_maintains_persistence_across_separate_get_calls() {
 
 #[test]
 fn sbf_store_serializes_concurrent_update_calls_without_data_loss() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sbf_store_abspath = store::utils::sbf_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
 
-    let sbf_store = SpaceBufferStore::get(&sbf_store_abspath).unwrap();
+    let sbf_store = SpaceBufferStore::get(tmp_space_abspath).unwrap();
 
     let handles: Vec<_> = (0..10)
         .map(|idx| {
@@ -405,12 +398,11 @@ fn sbf_store_serializes_concurrent_update_calls_without_data_loss() {
 
 #[test]
 fn sck_store_get_creates_default_when_file_doesnt_exist() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sck_store_abspath = store::utils::sck_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sck_store_abspath = store::utils::sck_store_abspath(tmp_space_abspath);
 
-    let sck_store = store::SpaceCookieStore::get(&sck_store_abspath).unwrap();
+    let sck_store = store::SpaceCookieStore::get(tmp_space_abspath).unwrap();
     let sck_store_mtx = sck_store.cookies.lock().unwrap();
 
     assert!(sck_store_mtx.iter_any().count() == 0);
@@ -419,10 +411,9 @@ fn sck_store_get_creates_default_when_file_doesnt_exist() {
 
 #[test]
 fn sck_store_get_loads_existing_store_from_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sck_store_abspath = store::utils::sck_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sck_store_abspath = store::utils::sck_store_abspath(tmp_space_abspath);
 
     if let Some(parent) = sck_store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -453,7 +444,7 @@ fn sck_store_get_loads_existing_store_from_filesystem() {
     ]);
     fs::write(&sck_store_abspath, cookie_json.to_string()).unwrap();
 
-    let sck_store = store::SpaceCookieStore::get(&sck_store_abspath).unwrap();
+    let sck_store = store::SpaceCookieStore::get(tmp_space_abspath).unwrap();
     let sck_store_mtx = sck_store.cookies.lock().unwrap();
 
     assert!(sck_store_mtx.iter_any().count() == 2);
@@ -462,10 +453,9 @@ fn sck_store_get_loads_existing_store_from_filesystem() {
 
 #[test]
 fn sck_store_handles_corrupt_cookie_json_by_using_default() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-    let sck_store_abspath = store::utils::sck_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sck_store_abspath = store::utils::sck_store_abspath(tmp_space_abspath);
 
     if let Some(parent) = sck_store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -473,7 +463,7 @@ fn sck_store_handles_corrupt_cookie_json_by_using_default() {
 
     fs::write(&sck_store_abspath, "invalid json {").unwrap();
 
-    let sck_store = store::SpaceCookieStore::get(&sck_store_abspath).unwrap();
+    let sck_store = store::SpaceCookieStore::get(tmp_space_abspath).unwrap();
     let sck_store_mtx = sck_store.cookies.lock().unwrap();
 
     assert!(sck_store_mtx.iter_any().count() == 0);
@@ -482,15 +472,10 @@ fn sck_store_handles_corrupt_cookie_json_by_using_default() {
 
 #[test]
 fn sst_store_get_creates_default_when_file_doesnt_exist() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-
-    let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-    let _state_store = StateStore::get(&state_store_abspath).unwrap();
-
-    let sst_store_abspath = store::utils::sst_store_abspath(datadir_abspath, &space_abspath);
-    let sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sst_store_abspath = store::utils::sst_store_abspath(tmp_space_abspath);
+    let sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
 
     assert_eq!(sst_store.theme, Theme::System);
     assert!(!sst_store.notifications.audio.on_req_finish);
@@ -499,14 +484,9 @@ fn sst_store_get_creates_default_when_file_doesnt_exist() {
 
 #[test]
 fn sst_store_get_loads_existing_settings_from_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-
-    let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-    let _state_store = StateStore::get(&state_store_abspath).unwrap();
-
-    let sst_store_abspath = store::utils::sst_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sst_store_abspath = store::utils::sst_store_abspath(tmp_space_abspath);
 
     if let Some(parent) = sst_store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -522,7 +502,7 @@ fn sst_store_get_loads_existing_settings_from_filesystem() {
     });
     fs::write(&sst_store_abspath, settings_json.to_string()).unwrap();
 
-    let sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
 
     assert_eq!(sst_store.theme, Theme::Dark);
     assert!(sst_store.notifications.audio.on_req_finish);
@@ -530,15 +510,10 @@ fn sst_store_get_loads_existing_settings_from_filesystem() {
 
 #[test]
 fn sst_store_update_persists_changes_to_filesystem() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-
-    let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-    let _state_store = StateStore::get(&state_store_abspath).unwrap();
-
-    let sst_store_abspath = store::utils::sst_store_abspath(datadir_abspath, &space_abspath);
-    let mut sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sst_store_abspath = store::utils::sst_store_abspath(tmp_space_abspath);
+    let mut sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
 
     sst_store
         .update(|settings| {
@@ -549,21 +524,16 @@ fn sst_store_update_persists_changes_to_filesystem() {
 
     assert!(sst_store_abspath.exists());
 
-    let fresh_sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let fresh_sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
     assert_eq!(fresh_sst_store.theme, Theme::Light);
     assert!(fresh_sst_store.notifications.audio.on_req_finish);
 }
 
 #[test]
 fn sst_store_handles_corrupt_json_by_using_default() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-
-    let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-    let _state_store = StateStore::get(&state_store_abspath).unwrap();
-
-    let sst_store_abspath = store::utils::sst_store_abspath(datadir_abspath, &space_abspath);
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
+    let sst_store_abspath = store::utils::sst_store_abspath(tmp_space_abspath);
 
     if let Some(parent) = sst_store_abspath.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -571,7 +541,7 @@ fn sst_store_handles_corrupt_json_by_using_default() {
 
     fs::write(&sst_store_abspath, "invalid json {").unwrap();
 
-    let sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
 
     assert_eq!(sst_store.theme, Theme::System);
     assert!(!sst_store.notifications.audio.on_req_finish);
@@ -580,20 +550,15 @@ fn sst_store_handles_corrupt_json_by_using_default() {
 
 #[test]
 fn sst_store_inherits_theme_from_state_store() {
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let datadir_abspath = tmp_dir.path();
-    let space_abspath = tmp_dir.path().join("test-space");
-
-    let state_store_abspath = store::utils::state_store_abspath(datadir_abspath);
-    let mut state_store = StateStore::get(&state_store_abspath).unwrap();
+    let (_tmp_datadir, tmp_spacedir, mut state_store) = store::utils::temp_space("Test Space");
+    let tmp_space_abspath = tmp_spacedir.path();
     state_store
         .update(|state| {
             state.user_settings.default_theme = Theme::Light;
         })
         .unwrap();
 
-    let sst_store_abspath = store::utils::sst_store_abspath(datadir_abspath, &space_abspath);
-    let sst_store = store::SpaceSettingsStore::get(&sst_store_abspath).unwrap();
+    let sst_store = store::SpaceSettingsStore::get(tmp_space_abspath).unwrap();
 
     assert_eq!(sst_store.theme, Theme::Light);
 }

--- a/src-tauri/src/store/utils.rs
+++ b/src-tauri/src/store/utils.rs
@@ -1,5 +1,11 @@
 use std::path::{Path, PathBuf};
 
+#[cfg(not(test))]
+use std::sync::LazyLock;
+
+#[cfg(test)]
+use std::cell::RefCell;
+
 use crate::utils;
 
 #[cfg(test)]
@@ -7,39 +13,98 @@ use crate::{space, space::models::CreateSpaceDto, store::StateStore};
 
 pub const SPACES_STORE_FSNAME: &str = "spaces";
 
+#[cfg(not(test))]
+pub static DATA_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+    dirs::data_dir()
+        .expect("Unable to get data directory")
+        .join("Zaku")
+});
+
+#[cfg(test)]
+thread_local! {
+    pub static DATA_DIR: RefCell<PathBuf> = RefCell::new(PathBuf::from("/tmp"));
+}
+
 /// Returns `StateStore`'s absolute path on the filesystem.
-pub fn state_store_abspath(datadir_abspath: &Path) -> PathBuf {
-    datadir_abspath.join("state.json")
+pub fn state_store_abspath() -> PathBuf {
+    #[cfg(not(test))]
+    {
+        DATA_DIR.join("state.json")
+    }
+
+    #[cfg(test)]
+    {
+        DATA_DIR.with(|path| path.borrow().join("state.json"))
+    }
 }
 
 /// Returns `SpaceBufferStore`'s absolute path on the filesystem for a given space.
-pub fn sbf_store_abspath(datadir_abspath: &Path, space_abspath: &Path) -> PathBuf {
+pub fn sbf_store_abspath(space_abspath: &Path) -> PathBuf {
     let hsh = utils::hashed_filename(space_abspath);
 
-    datadir_abspath
-        .join(SPACES_STORE_FSNAME)
-        .join(hsh)
-        .join("buffer.json")
+    #[cfg(not(test))]
+    {
+        DATA_DIR
+            .join(SPACES_STORE_FSNAME)
+            .join(hsh)
+            .join("buffer.json")
+    }
+
+    #[cfg(test)]
+    {
+        DATA_DIR.with(|path| {
+            path.borrow()
+                .join(SPACES_STORE_FSNAME)
+                .join(hsh)
+                .join("buffer.json")
+        })
+    }
 }
 
 /// Returns `SpaceCookieStore`'s absolute path on the filesystem for a given space.
-pub fn sck_store_abspath(datadir_abspath: &Path, space_abspath: &Path) -> PathBuf {
+pub fn sck_store_abspath(space_abspath: &Path) -> PathBuf {
     let hsh = utils::hashed_filename(space_abspath);
 
-    datadir_abspath
-        .join(SPACES_STORE_FSNAME)
-        .join(hsh)
-        .join("cookies.json")
+    #[cfg(not(test))]
+    {
+        DATA_DIR
+            .join(SPACES_STORE_FSNAME)
+            .join(hsh)
+            .join("cookies.json")
+    }
+
+    #[cfg(test)]
+    {
+        DATA_DIR.with(|path| {
+            path.borrow()
+                .join(SPACES_STORE_FSNAME)
+                .join(hsh)
+                .join("cookies.json")
+        })
+    }
 }
 
 /// Returns `SpaceSettingsStore`'s absolute path on the filesystem for a given space.
-pub fn sst_store_abspath(datadir_abspath: &Path, space_abspath: &Path) -> PathBuf {
+pub fn sst_store_abspath(space_abspath: &Path) -> PathBuf {
     let hsh = utils::hashed_filename(space_abspath);
 
-    datadir_abspath
-        .join(SPACES_STORE_FSNAME)
-        .join(hsh)
-        .join("settings.json")
+    #[cfg(not(test))]
+    {
+        DATA_DIR
+            .join(SPACES_STORE_FSNAME)
+            .join(hsh)
+            .join("settings.json")
+    }
+
+    #[cfg(test)]
+    {
+        DATA_DIR.with(|path| {
+            path.borrow()
+                .join(SPACES_STORE_FSNAME)
+                .join(hsh)
+                .join("settings.json")
+        })
+    }
 }
 
 /// Returns `SpaceCollectionsMetadataStore`'s absolute path on the filesystem for a given space.
@@ -57,13 +122,15 @@ pub fn temp_space(space_name: &str) -> (tempfile::TempDir, tempfile::TempDir, St
     let tmp_datadir = tempfile::tempdir().unwrap();
     let tmp_spacedir = tempfile::tempdir().unwrap();
 
-    let state_store_abspath = state_store_abspath(tmp_datadir.path());
+    DATA_DIR.with(|dir| {
+        *dir.borrow_mut() = tmp_datadir.path().to_path_buf();
+    });
+
     let dto = CreateSpaceDto {
         name: space_name.to_string(),
         location: tmp_spacedir.path().to_path_buf(),
     };
-    let mut state_store =
-        StateStore::get(&state_store_abspath).expect("Failed to init state store");
+    let mut state_store = StateStore::get().expect("Failed to init state store");
 
     space::create_space(dto, &mut state_store).expect("Failed to create test space");
 

--- a/src-tauri/src/tree_node/mod.rs
+++ b/src-tauri/src/tree_node/mod.rs
@@ -6,10 +6,10 @@ use std::{
 };
 
 use crate::{
-    collection::models::{Collection, SpaceCollectionsMetadataStore},
+    collection::models::Collection,
     error::{Error, Result},
     space,
-    store::StateStore,
+    store::collection::SpaceCollectionsMetadataStore,
 };
 
 #[cfg(test)]
@@ -166,12 +166,8 @@ fn cur_exists(cur_parent_col: &Collection, node_type: &NodeType, fsname: &str) -
 /// - `space_abspath`: Absolute path to the space directory
 ///
 /// Returns a `Result` indicating success or failure of the drop operation
-pub fn move_tree_node(
-    dto: &MoveTreeNodeDto,
-    space_abspath: &Path,
-    state_store: &StateStore,
-) -> Result<()> {
-    let space = space::parse_space(space_abspath, state_store)?;
+pub fn move_tree_node(dto: &MoveTreeNodeDto, space_abspath: &Path) -> Result<()> {
+    let space = space::parse_space(space_abspath)?;
 
     let cur_fsname = dto
         .cur_relpath

--- a/src-tauri/src/tree_node/tests.rs
+++ b/src-tauri/src/tree_node/tests.rs
@@ -12,7 +12,7 @@ use crate::{
 fn find_collection_returns_root_for_empty_path() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
 
     let result = tree_node::find_collection(&space, &PathBuf::from(""));
     assert!(result.is_ok());
@@ -34,7 +34,7 @@ fn find_collection_finds_direct_child() {
     collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create collection");
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let result = tree_node::find_collection(&space, &PathBuf::from("parent-col-1"));
     assert!(result.is_ok());
     let collection = result.unwrap();
@@ -57,7 +57,7 @@ fn find_collection_finds_nested_child() {
     collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create nested collection");
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let nested_path = PathBuf::from("parent-col-1/child-col-1");
     let result = tree_node::find_collection(&space, &nested_path);
     assert!(result.is_ok());
@@ -70,7 +70,7 @@ fn find_collection_finds_nested_child() {
 fn find_collection_fails_for_nonexistent_path() {
     let (_tmp_datadir, _tmp_spacedir, state_store) = store::utils::temp_space("Tree Space");
     let tmp_space_abspath = state_store.spaceref.as_ref().unwrap().abspath.clone();
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
 
     let result = tree_node::find_collection(&space, &PathBuf::from("nonexistent-col-1"));
     assert!(result.is_err());
@@ -97,7 +97,7 @@ fn find_collection_fails_for_partially_invalid_path() {
     collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let invalid_path = PathBuf::from("parent-col-1/missing-child-col-1");
     let result = tree_node::find_collection(&space, &invalid_path);
     assert!(result.is_err());
@@ -111,7 +111,7 @@ fn find_collection_fails_for_partially_invalid_path() {
 
 #[test]
 fn move_tree_node_fails_with_no_space() {
-    let (_tmp_datadir, tmp_spacedir, state_store) = store::utils::temp_space("Test Space");
+    let (_tmp_datadir, tmp_spacedir, _state_store) = store::utils::temp_space("Test Space");
     let tmp_nonexistent_space_abspath = tmp_spacedir.path().join("nonexistent");
 
     let dto = MoveTreeNodeDto {
@@ -120,7 +120,7 @@ fn move_tree_node_fails_with_no_space() {
         nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_nonexistent_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::FileNotFound(_) => {}
@@ -139,7 +139,7 @@ fn move_tree_node_fails_with_invalid_cur_relpath() {
         nxt_relpath: PathBuf::from("parent-col-1/child-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => assert_eq!(msg, "Invalid source path"),
@@ -168,7 +168,7 @@ fn move_tree_node_fails_when_moving_to_self() {
         nxt_relpath: PathBuf::from("parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
 }
 
@@ -209,7 +209,7 @@ fn move_tree_node_fails_when_moving_into_own_subtree() {
         nxt_relpath: PathBuf::from("parent-col-1/child-col/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
 }
 
@@ -234,7 +234,7 @@ fn move_tree_node_fails_when_moving_collection_into_itself() {
         nxt_relpath: PathBuf::from("parent-col-1/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => assert_eq!(msg, "Cannot move collection into itself"),
@@ -287,7 +287,7 @@ fn move_tree_node_fails_when_destination_already_exists() {
         nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => assert!(msg.contains("already exists")),
@@ -317,7 +317,7 @@ fn move_tree_node_fails_when_source_not_found() {
         nxt_relpath: PathBuf::from("parent-col-1/nonexistent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => assert!(msg.contains("not found")),
@@ -358,10 +358,10 @@ fn move_tree_node_successfully_moves_collection() {
         nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let parent_col = tree_node::find_collection(&space, &PathBuf::from("parent-col-2")).unwrap();
     let moved_collection = parent_col
         .collections
@@ -410,10 +410,10 @@ fn move_tree_node_successfully_moves_request() {
         nxt_relpath: PathBuf::from("parent-col-1/parent-req-1.toml"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let parent_col = tree_node::find_collection(&space, &PathBuf::from("parent-col-1")).unwrap();
     let moved_request = parent_col
         .requests
@@ -459,7 +459,7 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
     collection::create_collection(&location_relpath, &col_segment, &tmp_space_abspath)
         .expect("Failed to create parent collection");
 
-    let _space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let _space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     fs::remove_dir_all(tmp_space_abspath.join("parent-col-2"))
         .expect("Failed to remove parent directory");
 
@@ -469,7 +469,7 @@ fn move_tree_node_fails_with_missing_destination_parent_directory() {
         nxt_relpath: PathBuf::from("parent-col-2/parent-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_err());
     match result.unwrap_err() {
         Error::InvalidPath(msg) => {
@@ -501,10 +501,10 @@ fn move_tree_node_successfully_moves_collection_to_parent() {
         nxt_relpath: PathBuf::from("grand-parent-col-1/child-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let grandparent_col =
         tree_node::find_collection(&space, &PathBuf::from("grand-parent-col-1")).unwrap();
     let moved_collection = grandparent_col
@@ -570,10 +570,10 @@ fn move_tree_node_successfully_moves_request_to_parent() {
         nxt_relpath: PathBuf::from("grand-parent-col-1/grand-child-req-1.toml"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let grandparent_col =
         tree_node::find_collection(&space, &PathBuf::from("grand-parent-col-1")).unwrap();
     let moved_request = grandparent_col
@@ -632,10 +632,10 @@ fn move_tree_node_successfully_moves_collection_to_grandparent() {
         nxt_relpath: PathBuf::from("great-grand-parent-col-1/grand-parent-col-1/child-col-1"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let grandparent_path = PathBuf::from("great-grand-parent-col-1/grand-parent-col-1");
     let grandparent_col = tree_node::find_collection(&space, &grandparent_path).unwrap();
     let moved_collection = grandparent_col
@@ -704,10 +704,10 @@ fn move_tree_node_successfully_moves_request_to_grandparent() {
         nxt_relpath: PathBuf::from("great-grand-parent-col-1/great-grand-child-req-1.toml"),
     };
 
-    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath, &state_store);
+    let result = tree_node::move_tree_node(&dto, &tmp_space_abspath);
     assert!(result.is_ok());
 
-    let space = collection::parse_root_collection(&tmp_space_abspath, &state_store).unwrap();
+    let space = collection::parse_root_collection(&tmp_space_abspath).unwrap();
     let great_grandparent_col =
         tree_node::find_collection(&space, &PathBuf::from("great-grand-parent-col-1")).unwrap();
     let moved_request = great_grandparent_col

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -61,10 +61,7 @@ export const commands = {
     spaceAbspath: string,
   ): Promise<Result<Partial<{ [key in string]: SerializedCookie[] }>, CmdErr>> {
     try {
-      return {
-        status: "ok",
-        data: await TAURI_INVOKE("get_space_cookies", { spaceAbspath }),
-      };
+      return { status: "ok", data: await TAURI_INVOKE("get_space_cookies", { spaceAbspath }) };
     } catch (e) {
       if (e instanceof Error) throw e;
       else return { status: "error", error: e as any };


### PR DESCRIPTION
- use LazyLock in production and thread_local! in tests
- remove datadir params from all store method signatures