### PR TITLE
Add breadcrumbs to workspace tabs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -401,6 +401,7 @@ pub struct Editor {
     scroll_manager: scroll::ScrollManager,
     mode: EditorMode,
     placeholder: SharedString,
+    breadcrumb_header: Option<String>,
     defer_selection_effects: bool,
     deferred_selection_effects_state: Option<DeferredSelectionEffectsState>,
     last_position_map: Option<Rc<PositionMap>>,
@@ -522,6 +523,7 @@ impl Editor {
             scroll_manager,
             mode,
             placeholder: SharedString::default(),
+            breadcrumb_header: None,
             defer_selection_effects: false,
             deferred_selection_effects_state: None,
             last_position_map: None,
@@ -1319,6 +1321,10 @@ impl Editor {
 
     pub fn set_read_only(&mut self, read_only: bool) {
         self.read_only = read_only;
+    }
+
+    pub fn set_breadcrumb_header(&mut self, new_header: String) {
+        self.breadcrumb_header = Some(new_header);
     }
 
     pub fn set_current_line_highlight(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1,5 +1,8 @@
 use anyhow::anyhow;
-use gpui::{App, AppContext, Context, Entity, EntityId, SharedString, Task, WeakEntity, Window};
+use gpui::{
+    AnyElement, App, AppContext, Context, Entity, EntityId, SharedString, Task, WeakEntity, Window,
+    prelude::*,
+};
 use std::{borrow::Cow, path::Path, sync::Arc};
 
 use git::status::GitSummary;
@@ -8,10 +11,11 @@ use multi_buffer::MultiBuffer;
 use path::PathExt;
 use project::Project;
 use svg::FileIcon;
-use ui::{Color, Icon};
+use ui::{Color, Icon, LineHeightStyle, Text, TextCommon, TextSize};
+use util::truncate_and_trailoff;
 use workspace::{
-    Item, ItemBufferKind, ItemEvent, ItemId, ProjectItem, SerializableItem, Workspace, WorkspaceId,
-    delete_unloaded_items, pane::Pane,
+    Item, ItemBufferKind, ItemEvent, ItemId, ProjectItem, SerializableItem, TabContentParams,
+    ToolbarItemLocation, Workspace, WorkspaceId, delete_unloaded_items, pane::Pane,
 };
 
 use crate::{
@@ -20,17 +24,42 @@ use crate::{
     scroll::Autoscroll,
 };
 
+const MAX_TAB_TITLE_LEN: usize = 24;
+
 impl Item for Editor {
     type Event = EditorEvent;
 
     fn to_item_events(event: &Self::Event, emitter: &mut dyn FnMut(ItemEvent)) {
         match event {
-            EditorEvent::Saved | EditorEvent::TitleChanged | EditorEvent::DirtyChanged => {
+            EditorEvent::Saved | EditorEvent::TitleChanged => {
                 emitter(ItemEvent::UpdateTab);
+                emitter(ItemEvent::UpdateBreadcrumbs);
             }
+            EditorEvent::DirtyChanged => emitter(ItemEvent::UpdateTab),
             EditorEvent::BufferEdited => emitter(ItemEvent::Edit),
             EditorEvent::Blurred | EditorEvent::FileHandleChanged => {}
         }
+    }
+
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        if self.buffer.read(cx).as_singleton().is_some() {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>> {
+        let multi_buffer = self.buffer.read(cx);
+        let buffer = multi_buffer.as_singleton()?;
+        let snapshot = buffer.read(cx).snapshot();
+        let include_context = project::File::from_dyn(snapshot.file())
+            .is_some_and(|file| !file.worktree.read(cx).is_visible());
+        let text = snapshot
+            .resolve_file_path(include_context, cx)
+            .unwrap_or_else(|| multi_buffer.title(cx).into_owned());
+
+        Some(vec![text.into()])
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
@@ -39,6 +68,41 @@ impl Item for Editor {
         } else {
             self.buffer.read(cx).title(cx).to_string().into()
         }
+    }
+
+    fn tab_content(&self, params: TabContentParams, _: &Window, cx: &App) -> AnyElement {
+        let title = self.buffer.read(cx).title(cx).into_owned();
+        let title = Text::new(truncate_and_trailoff(&title, MAX_TAB_TITLE_LEN))
+            .color(entry_text_color(params.selected))
+            .when(params.preview, |this| this.italic())
+            .when(self.buffer.read(cx).has_deleted_file(cx), |this| {
+                this.strikethrough()
+            });
+        let description = params.detail.and_then(|detail| {
+            let path = path_for_buffer(&self.buffer, detail, false, cx)?;
+            let description = path.trim();
+            if description.is_empty() {
+                return None;
+            }
+
+            Some(truncate_and_trailoff(description, MAX_TAB_TITLE_LEN))
+        });
+
+        gpui::div()
+            .flex()
+            .items_center()
+            .min_w_0()
+            .gap_1()
+            .child(title)
+            .when_some(description, |this, description| {
+                this.child(
+                    Text::new(description)
+                        .size(TextSize::XSmall)
+                        .line_height_style(LineHeightStyle::Compact)
+                        .color(Color::Muted),
+                )
+            })
+            .into_any_element()
     }
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
@@ -455,5 +519,58 @@ mod tests {
             pane.read_with(cx, |pane, _| pane.items_len()),
             pane_items_before
         );
+    }
+
+    #[gpui::test]
+    async fn test_settings_file_breadcrumbs(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let temp_fs = TempFs::new(cx.executor());
+        let app_state = cx.update(|cx| AppState::test_new(temp_fs.clone(), None, cx));
+        init_test(app_state, cx);
+
+        temp_fs.insert_tree(path!("project"), json!(null));
+        temp_fs.insert_tree(
+            path!("config"),
+            json!({
+                "settings.jsonc": r#"{ "ui": { "density": "default" } }"#
+            }),
+        );
+
+        let project_path = temp_fs.path().join(path!("project"));
+        let config_dir = temp_fs.path().join(path!("config"));
+        let settings_path = config_dir.join(path!("settings.jsonc"));
+        let project = Project::test_new(temp_fs.clone(), &project_path, cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(&config_dir, false, cx)
+            })
+            .await
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer_at(&settings_path, cx))
+            .await
+            .unwrap();
+        let (workspace, cx) = build_workspace(&project, cx);
+        let editor = workspace.update_in(cx, |_, window, cx| {
+            cx.new(|cx| Editor::for_buffer(buffer, window, cx))
+        });
+
+        editor.update(cx, |editor, cx| {
+            assert_eq!(
+                editor.breadcrumb_location(cx),
+                ToolbarItemLocation::PrimaryLeft
+            );
+            pretty_assertions::assert_eq!(
+                editor.breadcrumbs(cx),
+                Some(vec![
+                    settings_path
+                        .compact()
+                        .to_string_lossy()
+                        .into_owned()
+                        .into()
+                ])
+            );
+        });
     }
 }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -52,12 +52,14 @@ impl Item for Editor {
     fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>> {
         let multi_buffer = self.buffer.read(cx);
         let buffer = multi_buffer.as_singleton()?;
-        let snapshot = buffer.read(cx).snapshot();
-        let include_context = project::File::from_dyn(snapshot.file())
-            .is_some_and(|file| !file.worktree.read(cx).is_visible());
-        let text = snapshot
-            .resolve_file_path(include_context, cx)
-            .unwrap_or_else(|| multi_buffer.title(cx).into_owned());
+        let text = self.breadcrumb_header.clone().unwrap_or_else(|| {
+            let snapshot = buffer.read(cx).snapshot();
+            let include_context = project::File::from_dyn(snapshot.file())
+                .is_some_and(|file| !file.worktree.read(cx).is_visible());
+            snapshot
+                .resolve_file_path(include_context, cx)
+                .unwrap_or_else(|| multi_buffer.title(cx).into_owned())
+        });
 
         Some(vec![text.into()])
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -65,6 +65,15 @@ impl BufferSnapshot {
         self.file.as_ref()
     }
 
+    pub fn resolve_file_path(&self, include_context: bool, cx: &App) -> Option<String> {
+        let file = self.file()?;
+        if file.path().file_name().is_none() || include_context {
+            Some(file.full_path(cx).to_string_lossy().into_owned())
+        } else {
+            Some(file.path().display(file.path_style(cx)).to_string())
+        }
+    }
+
     pub fn non_text_state_update_count(&self) -> usize {
         self.non_text_state_update_count
     }

--- a/crates/request_editor/src/items.rs
+++ b/crates/request_editor/src/items.rs
@@ -8,7 +8,7 @@ use editor::items::{entry_git_aware_text_color, entry_text_color};
 use path::PathExt;
 use project::{Project, RequestBuffer, RequestFileState};
 use settings::{GitSettings, Settings};
-use ui::{Color, Icon, IconAsset, IconSize, Text, TextCommon, TextSize};
+use ui::{Color, Icon, IconAsset, IconSize, LineHeightStyle, Text, TextCommon, TextSize};
 use util::truncate_and_trailoff;
 use workspace::{
     Item, ItemBufferKind, ItemEvent, ItemId, ProjectItem, SerializableItem, TabContentParams,
@@ -135,6 +135,7 @@ impl Item for RequestEditor {
                 this.child(
                     Text::new(description)
                         .size(TextSize::XSmall)
+                        .line_height_style(LineHeightStyle::Compact)
                         .color(Color::Muted),
                 )
             })

--- a/crates/request_editor/src/items.rs
+++ b/crates/request_editor/src/items.rs
@@ -12,7 +12,7 @@ use ui::{Color, Icon, IconAsset, IconSize, Text, TextCommon, TextSize};
 use util::truncate_and_trailoff;
 use workspace::{
     Item, ItemBufferKind, ItemEvent, ItemId, ProjectItem, SerializableItem, TabContentParams,
-    Workspace, WorkspaceId, delete_unloaded_items, pane::Pane,
+    ToolbarItemLocation, Workspace, WorkspaceId, delete_unloaded_items, pane::Pane,
 };
 
 use crate::{
@@ -27,14 +27,27 @@ impl Item for RequestEditor {
 
     fn to_item_events(event: &Self::Event, emitter: &mut dyn FnMut(ItemEvent)) {
         match event {
-            RequestEditorEvent::Saved
-            | RequestEditorEvent::TitleChanged
-            | RequestEditorEvent::DirtyChanged => {
+            RequestEditorEvent::TitleChanged => {
+                emitter(ItemEvent::UpdateTab);
+                emitter(ItemEvent::UpdateBreadcrumbs);
+            }
+            RequestEditorEvent::Saved | RequestEditorEvent::DirtyChanged => {
                 emitter(ItemEvent::UpdateTab);
             }
             RequestEditorEvent::RequestBufferEdited => emitter(ItemEvent::Edit),
             RequestEditorEvent::FileHandleChanged => {}
         }
+    }
+
+    fn breadcrumb_location(&self, _: &App) -> ToolbarItemLocation {
+        ToolbarItemLocation::PrimaryLeft
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>> {
+        let project_path = self.project_path(cx)?;
+        let path = project_path.path.display(self.path_style(cx)).into_owned();
+
+        Some(vec![path.into()])
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
@@ -72,9 +85,11 @@ impl Item for RequestEditor {
         } else {
             entry_text_color(params.selected)
         };
+        let was_deleted = self.buffer.read(cx).file().disk_state.is_deleted();
         let title = Text::new(truncate_and_trailoff(&self.title(cx), MAX_TAB_TITLE_LEN))
             .color(text_color)
-            .when(params.preview, |this| this.italic());
+            .when(params.preview, |this| this.italic())
+            .when(was_deleted, |this| this.strikethrough());
         let description = params.detail.and_then(|detail| {
             let path = self.path_for_request(detail, false, cx)?;
             let description = path.trim();
@@ -330,7 +345,7 @@ mod tests {
     use std::sync::Arc;
 
     use fs::TempFs;
-    use path::rel_path;
+    use path::{PathStyle, rel_path};
     use settings::SettingsStore;
     use theme::LoadThemes;
     use util_macros::path;
@@ -416,6 +431,66 @@ mod tests {
             assert_eq!(
                 request_editor.buffer.read(cx).file().path.as_ref(),
                 rel_path("collection/request.toml")
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_breadcrumbs(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let temp_fs = TempFs::new(cx.executor());
+        let app_state = cx.update(|cx| AppState::test_new(temp_fs.clone(), None, cx));
+        init_test(app_state, cx);
+
+        temp_fs.insert_tree(
+            path!("project"),
+            json!({
+                "collection": {
+                    "request.toml": indoc! {r#"
+                        [meta]
+                        version = 1
+
+                        [http]
+                        method = "GET"
+                        url = "https://api.zaku.dev"
+                    "#}
+                }
+            }),
+        );
+
+        let project_path = temp_fs.path().join(path!("project"));
+        let project = Project::test_new(temp_fs.clone(), &project_path, cx).await;
+        let worktree_id = cx.update(|cx| project.read(cx).root_worktree(cx).unwrap().read(cx).id());
+        let (workspace, cx) = build_workspace(&project, cx);
+        let request_editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    (worktree_id, rel_path("collection/request.toml")).into(),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<RequestEditor>()
+            .unwrap();
+
+        request_editor.read_with(cx, |request_editor, cx| {
+            assert_eq!(
+                request_editor.breadcrumb_location(cx),
+                ToolbarItemLocation::PrimaryLeft
+            );
+            assert_eq!(
+                request_editor.breadcrumbs(cx),
+                Some(vec![
+                    rel_path("collection/request.toml")
+                        .display(PathStyle::local())
+                        .into_owned()
+                        .into()
+                ])
             );
         });
     }

--- a/crates/request_editor/src/request_editor.rs
+++ b/crates/request_editor/src/request_editor.rs
@@ -1754,9 +1754,6 @@ impl RequestEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Div {
-        let request_relative_path = self.project_path(cx).map(|project_path| {
-            SharedString::from(project_path.path.display(self.path_style(cx)).into_owned())
-        });
         let url = request.http.url.clone();
         let request_method_menu = {
             let available_request_methods = [
@@ -1813,17 +1810,6 @@ impl RequestEditor {
             .track_focus(&self.focus_handle)
             .size_full()
             .bg(colors.panel_background)
-            .when_some(request_relative_path, |this, request_relative_path| {
-                this.child(
-                    gpui::div()
-                        .flex()
-                        .items_center()
-                        .w_full()
-                        .px_3()
-                        .pt_2()
-                        .child(Text::new(request_relative_path)),
-                )
-            })
             .child(
                 gpui::div()
                     .flex()

--- a/crates/workspace/src/breadcrumbs.rs
+++ b/crates/workspace/src/breadcrumbs.rs
@@ -36,7 +36,7 @@ impl Render for Breadcrumbs {
             .id("breadcrumb-container")
             .flex()
             .flex_grow_1()
-            .h_8()
+            .h_6()
             .items_center()
             .overflow_x_scroll()
             .text_ui(cx);

--- a/crates/workspace/src/breadcrumbs.rs
+++ b/crates/workspace/src/breadcrumbs.rs
@@ -1,0 +1,116 @@
+use gpui::{
+    Context, EventEmitter, IntoElement, ParentElement, Render, Subscription, Window, prelude::*,
+};
+
+use ui::{Color, StyledTypography, Text, TextCommon};
+
+use crate::{ItemEvent, ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
+
+pub struct Breadcrumbs {
+    active_item: Option<Box<dyn ItemHandle>>,
+    active_item_subscription: Option<Subscription>,
+}
+
+impl Breadcrumbs {
+    pub fn new() -> Self {
+        Self {
+            active_item: None,
+            active_item_subscription: None,
+        }
+    }
+}
+
+impl Default for Breadcrumbs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for Breadcrumbs {}
+
+impl Render for Breadcrumbs {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        const MAX_SEGMENTS: usize = 12;
+
+        let element = gpui::div()
+            .id("breadcrumb-container")
+            .flex()
+            .flex_grow_1()
+            .h_8()
+            .items_center()
+            .overflow_x_scroll()
+            .text_ui(cx);
+
+        let Some(active_item) = self.active_item.as_ref() else {
+            return element;
+        };
+
+        let Some(mut segments) = active_item.breadcrumbs(cx) else {
+            return element;
+        };
+
+        if segments.len() > MAX_SEGMENTS {
+            let prefix_end_index = MAX_SEGMENTS / 2;
+            let suffix_start_index = segments.len() - MAX_SEGMENTS / 2;
+            segments.splice(prefix_end_index..suffix_start_index, Some("⋯".into()));
+        }
+
+        let segment_elements = segments.into_iter().map(|segment| {
+            Text::new(segment.replace('\n', " "))
+                .color(Color::Muted)
+                .font_buffer(cx)
+                .into_any_element()
+        });
+
+        let breadcrumb_elements = itertools::intersperse_with(segment_elements, || {
+            Text::new("›").color(Color::Placeholder).into_any_element()
+        });
+
+        let breadcrumbs = gpui::div()
+            .flex()
+            .items_center()
+            .gap_1()
+            .children(breadcrumb_elements);
+
+        element.child(breadcrumbs)
+    }
+}
+
+impl ToolbarItemView for Breadcrumbs {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        cx.notify();
+        self.active_item = None;
+        let _previous_subscription = self.active_item_subscription.take();
+
+        let Some(item) = active_pane_item else {
+            return ToolbarItemLocation::Hidden;
+        };
+
+        let this = cx.entity().downgrade();
+        self.active_item_subscription = Some(item.subscribe_to_item_events(
+            window,
+            cx,
+            Box::new(move |event, _, cx| {
+                if let ItemEvent::UpdateBreadcrumbs = event
+                    && let Err(error) = this.update(cx, |this, cx| {
+                        cx.notify();
+                        if let Some(active_item) = this.active_item.as_ref() {
+                            cx.emit(ToolbarItemEvent::ChangeLocation(
+                                active_item.breadcrumb_location(cx),
+                            ));
+                        }
+                    })
+                {
+                    log::debug!("Failed to update breadcrumbs: {error:?}");
+                }
+            }),
+        ));
+        self.active_item = Some(item.boxed_clone());
+        item.breadcrumb_location(cx)
+    }
+}

--- a/crates/workspace/src/breadcrumbs.rs
+++ b/crates/workspace/src/breadcrumbs.rs
@@ -2,7 +2,7 @@ use gpui::{
     Context, EventEmitter, IntoElement, ParentElement, Render, Subscription, Window, prelude::*,
 };
 
-use ui::{Color, StyledTypography, Text, TextCommon};
+use ui::{Color, StyledTypography, Text, TextCommon, TextSize};
 
 use crate::{ItemEvent, ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 
@@ -58,12 +58,16 @@ impl Render for Breadcrumbs {
         let segment_elements = segments.into_iter().map(|segment| {
             Text::new(segment.replace('\n', " "))
                 .color(Color::Muted)
+                .size(TextSize::Editor)
                 .font_buffer(cx)
                 .into_any_element()
         });
 
         let breadcrumb_elements = itertools::intersperse_with(segment_elements, || {
-            Text::new("›").color(Color::Placeholder).into_any_element()
+            Text::new("›")
+                .color(Color::Placeholder)
+                .size(TextSize::Editor)
+                .into_any_element()
         });
 
         let breadcrumbs = gpui::div()

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -10,13 +10,15 @@ use project::{Project, ProjectEntryId, ProjectPath};
 use ui::{Color, Icon, Text, TextCommon};
 
 use crate::{
-    SerializableItemRegistry, Workspace, WorkspaceId, pane::Pane, persistence::model::ItemId,
+    SerializableItemRegistry, ToolbarItemLocation, Workspace, WorkspaceId, pane::Pane,
+    persistence::model::ItemId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemEvent {
     CloseItem,
     UpdateTab,
+    UpdateBreadcrumbs,
     Edit,
 }
 
@@ -73,6 +75,14 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
 
     fn tab_tooltip_content(&self, cx: &App) -> Option<TabTooltipContent> {
         self.tab_tooltip_text(cx).map(TabTooltipContent::Text)
+    }
+
+    fn breadcrumb_location(&self, _: &App) -> ToolbarItemLocation {
+        ToolbarItemLocation::Hidden
+    }
+
+    fn breadcrumbs(&self, _: &App) -> Option<Vec<SharedString>> {
+        None
     }
 
     fn to_item_events(_event: &Self::Event, _emitter: &mut dyn FnMut(ItemEvent)) {}
@@ -223,6 +233,8 @@ pub trait ItemHandle: 'static + Send {
     fn tab_icon(&self, window: &Window, cx: &App) -> Option<Icon>;
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString>;
     fn tab_tooltip_content(&self, cx: &App) -> Option<TabTooltipContent>;
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation;
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>>;
     fn project_path(&self, cx: &App) -> Option<ProjectPath>;
     fn project_entry_ids(&self, cx: &App) -> SmallVec<[ProjectEntryId; 3]>;
     fn for_each_project_item(
@@ -313,6 +325,14 @@ impl<T: Item> ItemHandle for Entity<T> {
         self.read(cx).tab_tooltip_content(cx)
     }
 
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        self.read(cx).breadcrumb_location(cx)
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>> {
+        self.read(cx).breadcrumbs(cx)
+    }
+
     fn project_path(&self, cx: &App) -> Option<ProjectPath> {
         let this = self.read(cx);
         let mut result = None;
@@ -392,6 +412,17 @@ impl<T: Item> ItemHandle for Entity<T> {
                     }
 
                     T::to_item_events(event, &mut |item_event| {
+                        if let ItemEvent::UpdateBreadcrumbs = item_event {
+                            let is_active_item = &pane == workspace.pane()
+                                && pane.read(cx).active_item().is_some_and(|active_item| {
+                                    active_item.item_id() == item.item_id()
+                                });
+                            if is_active_item {
+                                workspace.active_item_path_changed(cx);
+                            }
+                            return;
+                        }
+
                         pane.update(cx, |pane, cx| {
                             pane.handle_item_event(item.item_id(), item_event, window, cx);
                         });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -826,6 +826,7 @@ impl Pane {
                 cx.emit(PaneEvent::ChangeItemTitle);
                 cx.notify();
             }
+            ItemEvent::UpdateBreadcrumbs => {}
             ItemEvent::Edit => {
                 self.handle_item_edit(item_id, cx);
                 cx.notify();

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -198,7 +198,7 @@ impl Render for Toolbar {
                         .when(has_left_items, |row| {
                             row.child(
                                 gpui::div()
-                                    .min_h_8()
+                                    .min_h_6()
                                     .flex()
                                     .flex_1()
                                     .justify_start()
@@ -209,7 +209,7 @@ impl Render for Toolbar {
                         .when(has_right_items, |row| {
                             row.child(
                                 gpui::div()
-                                    .h_8()
+                                    .h_6()
                                     .flex()
                                     .flex_row_reverse()
                                     .when(has_left_items, |right_items| right_items.flex_none())

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1,3 +1,4 @@
+mod breadcrumbs;
 pub mod dock;
 pub mod item;
 mod modal_layer;
@@ -8,6 +9,7 @@ pub mod status_bar;
 pub mod toolbar;
 pub mod welcome;
 
+pub use breadcrumbs::Breadcrumbs;
 pub use dock::{DockPosition, DraggedDock, Panel, PanelHandle};
 pub use item::{
     Item, ItemBufferKind, ItemEvent, ItemHandle, ProjectItem, SerializableItem,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -55,7 +55,7 @@ use git::{
     REBASE_APPLY_DIR, REBASE_MERGE_DIR, REPO_EXCLUDE, SEQUENCER_DIR, status::GitSummary,
 };
 use language::{LineEnding, Rope};
-use path::{PathStyle, RelPath, SanitizedPath};
+use path::{PathExt, PathStyle, RelPath, SanitizedPath};
 use util::ResultExt;
 
 use crate::ignore::{IgnoreKind, IgnoreStack};
@@ -177,11 +177,15 @@ impl Worktree {
     }
 
     pub fn full_path(&self, worktree_relative_path: &RelPath) -> PathBuf {
-        self.root_name()
-            .join(worktree_relative_path)
-            .display(self.path_style())
-            .to_string()
-            .into()
+        if self.is_visible() {
+            self.root_name()
+                .join(worktree_relative_path)
+                .display(self.path_style())
+                .to_string()
+                .into()
+        } else {
+            self.absolutize(worktree_relative_path).compact()
+        }
     }
 
     pub fn write_request_file(

--- a/crates/zaku/src/logs.rs
+++ b/crates/zaku/src/logs.rs
@@ -7,10 +7,11 @@ use std::{any::Any, collections::VecDeque, sync::Arc};
 use editor::{Editor, EditorEvent};
 use language::{Buffer, Capability};
 use multi_buffer::MultiBuffer;
+use path::PathExt;
 use svg::FileIcon;
 use ui::Icon;
 use workspace::{
-    Item, ItemEvent, Workspace,
+    Item, ItemEvent, ToolbarItemLocation, Workspace,
     notifications::{NotificationId, simple_message_notification::MessageNotification},
 };
 
@@ -55,6 +56,14 @@ impl Item for LogsView {
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
         self.editor.read(cx).tab_content_text(detail, cx)
+    }
+
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        self.editor.read(cx).breadcrumb_location(cx)
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<SharedString>> {
+        self.editor.read(cx).breadcrumbs(cx)
     }
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
@@ -157,6 +166,10 @@ pub(crate) fn open_log_file(
             let editor = cx.new(|cx| {
                 let mut editor = Editor::for_multibuffer(buffer, window, cx);
                 editor.set_read_only(true);
+                editor.set_breadcrumb_header(format!(
+                    "Last {MAX_LINES} lines in {}",
+                    path::log_file().compact().display()
+                ));
                 editor.move_selection_to_end(cx);
                 editor
             });

--- a/crates/zaku/src/zaku.rs
+++ b/crates/zaku/src/zaku.rs
@@ -14,9 +14,9 @@ use project_panel::ProjectPanel;
 use response_panel::ResponsePanel;
 use system_specs::SystemSpecs;
 use workspace::{
-    AppState, CloseIntent, DockPosition, OpenMode, Panel, Root, SessionWorkspace, Toast, Workspace,
-    WorkspaceDb, WorkspaceEvent, create_and_open_file, notifications::NotificationId, pane::Pane,
-    with_active_or_new_workspace,
+    AppState, Breadcrumbs, CloseIntent, DockPosition, OpenMode, Panel, Root, SessionWorkspace,
+    Toast, Workspace, WorkspaceDb, WorkspaceEvent, create_and_open_file,
+    notifications::NotificationId, pane::Pane, with_active_or_new_workspace,
 };
 
 use crate::{logs::open_log_file, settings::migrate::MigrationBanner};
@@ -116,6 +116,9 @@ fn initialize_pane_toolbar(pane: &Entity<Pane>, window: &mut Window, cx: &mut Co
     let workspace_handle = cx.weak_entity();
     pane.update(cx, |pane, cx| {
         pane.toolbar().update(cx, |toolbar, cx| {
+            let breadcrumbs = cx.new(|_| Breadcrumbs::new());
+            toolbar.add_item(breadcrumbs, window, cx);
+
             let migration_banner =
                 cx.new(move |inner_cx| MigrationBanner::new(workspace_handle, inner_cx));
             toolbar.add_item(migration_banner, window, cx);


### PR DESCRIPTION
Show breadcrumbs above tab content for editor, request editor and log items. Resolve settings files and other hidden worktree files to compact absolute paths.